### PR TITLE
fix bug :pg always in active+remapped status when setting zones

### DIFF
--- a/source/vsm-dashboard/vsm_dashboard/dashboards/vsm/usermgmt/forms.py
+++ b/source/vsm-dashboard/vsm_dashboard/dashboards/vsm/usermgmt/forms.py
@@ -15,7 +15,12 @@
 # under the License.
 
 from django.core.urlresolvers import reverse
-from django.utils.translation import force_text, ugettext_lazy as _
+try:
+    from django.utils.translation import force_unicode
+except:
+    from django.utils.translation import force_text as force_unicode
+
+from django.utils.translation import  ugettext_lazy as _
 
 from horizon import exceptions
 from horizon import forms
@@ -178,7 +183,7 @@ class UpdateUserForm(BaseUserForm):
         if succeeded:
             messages.success(request, _('User has been updated successfully.'))
         if failed:
-            failed = map(force_text, failed)
+            failed = map(force_unicode, failed)
             messages.error(request,
                            _('Unable to update %(attributes)s for the user.')
                              % {"attributes": ", ".join(failed)})

--- a/source/vsm/vsm/agent/driver.py
+++ b/source/vsm/vsm/agent/driver.py
@@ -2259,7 +2259,7 @@ class CreateCrushMapDriver(object):
                     item["weight"] = zone["weight"]
                     item["zone_name"] = zone["name"]
                     items.append(item)
-                    weight = weight + zone["weight"]
+                    weight = weight + float(zone["weight"])
             dic["weight"] = (weight != 0 and weight or FLAGS.default_weight)
             dic["item"] = items
             num = num - 1

--- a/source/vsm/vsm/diamond/diamond.conf
+++ b/source/vsm/vsm/diamond/diamond.conf
@@ -66,22 +66,6 @@ timeout = 15
 # Batch size for metrics
 batch = 1
 
-[[GraphitePickleHandler]]
-### Options for GraphitePickleHandler
-
-# Graphite server host
-host = 127.0.0.1
-
-# Port to send metrics to
-port = 2004
-
-# Socket timeout (seconds)
-timeout = 15
-
-# Batch size for pickled metrics
-
-# Batch size for metrics
-batch = 1
 
 [[GraphitePickleHandler]]
 ### Options for GraphitePickleHandler


### PR DESCRIPTION
1.pg always in active+remapped status when setting zones in cluster.manifest and server.manifest
2.make force_text and  force_unicode both work in django 1.4 and django 1.6
3.remove reduplicate code in diamond.conf