### PR TITLE
VSM-53: initial support for integration of existing clusters not basing on ceph.conf

### DIFF
--- a/source/vsm/vsm/agent/driver.py
+++ b/source/vsm/vsm/agent/driver.py
@@ -1709,6 +1709,22 @@ class CephDriver(object):
         else:
             return None
 
+    def get_osds_details(self):
+        args = ['ceph', 'osd', 'dump']
+        osd_dump = self._run_cmd_to_json(args)
+        if osd_dump:
+            return osd_dump['osds']
+        else:
+            return None
+
+    def get_osds_metadata(self):
+        args = ['ceph', 'report']
+        report = self._run_cmd_to_json(args)
+        if report:
+            return report['osd_metadata']
+        else:
+            return None
+
     def get_ceph_health_list(self):
         args = ['ceph', 'health']
         out, _err = utils.execute(*args, run_as_root=True)

--- a/source/vsm/vsm/agent/driver.py
+++ b/source/vsm/vsm/agent/driver.py
@@ -481,6 +481,25 @@ class CephDriver(object):
         self.__format_devs(osd_disks + journal_disks, file_system)
         return {'status': 'ok'}
 
+    def get_dev_by_mpoint(self, directory):
+        def _parse_proc_partitions():
+            parts = {}
+            for line in file('/proc/partitions'):
+                fields = line.split()
+                try:
+                    dmaj = int(fields[0])
+                    dmin = int(fields[1])
+                    name = fields[3]
+                    parts[(dmaj, dmin)] = name
+                except:
+                    pass
+            return parts
+
+        dev = os.stat(directory).st_dev
+        major, minor = os.major(dev), os.minor(dev)
+        parts = _parse_proc_partitions()
+        return '/dev/' + parts[(major, minor)]
+
     def mount_disks(self, devices, fs_type):
         def __mount_disk(disk):
             utils.execute('mkdir',

--- a/source/vsm/vsm/agent/manager.py
+++ b/source/vsm/vsm/agent/manager.py
@@ -944,6 +944,16 @@ class AgentManager(manager.Manager):
             else:
                 return None
 
+        def _get_zone_id():
+            zone_ref = db.zone_get_by_name(self._context,
+                                           self._node_info['zone'])
+            if zone_ref:
+                zone_id = zone_ref['id']
+            else:
+                LOG.error("Can't find the zone in DB!")
+                raise
+            return zone_id
+
         for osd_md in _get_local_osds_metadata():
             osd_num = osd_md['id']
             osd_det = _get_osd_detail_by_id(osd_num)
@@ -968,7 +978,7 @@ class AgentManager(manager.Manager):
             values['cluster_id'] = 1
             values['weight'] = 1.0
             values['storage_group_id'] = _get_storage_group_id_by_dev(osd_dev)
-            values['zone_id'] = 1
+            values['zone_id'] = _get_zone_id()
             values['operation_status'] = 'Present'
 
             self._conductor_rpcapi.\

--- a/source/vsm/vsm/agent/manager.py
+++ b/source/vsm/vsm/agent/manager.py
@@ -897,7 +897,12 @@ class AgentManager(manager.Manager):
         self.sync_osd_states_from_ceph(context)
         return True
 
-    def sync_osd_states_from_cluster(self, context):
+    def integrate_cluster_update_status(self, context):
+        LOG.info("integrating cluster: updatating global status")
+        self.update_all_status(context)
+        return True
+
+    def integrate_cluster_sync_osd_states(self, context):
         def _determine_status(osd):
             if osd['in'] and osd['up']:
                 osd_status = FLAGS.osd_in_up
@@ -932,7 +937,7 @@ class AgentManager(manager.Manager):
 
             values = {}
             values['osd_name'] = osd_name
-            values['state'] =  _determine_status(osd_det)
+            values['state'] = _determine_status(osd_det)
             node = db.init_node_get_by_host(context , self.host)
             values['service_id'] = node['service_id']
             values['cluster_ip'] = osd_det['cluster_addr']

--- a/source/vsm/vsm/agent/manager.py
+++ b/source/vsm/vsm/agent/manager.py
@@ -975,7 +975,7 @@ class AgentManager(manager.Manager):
                 continue
 
             values['device_id'] = device['id']
-            values['cluster_id'] = 1
+            values['cluster_id'] = self._get_cluster_id(context)
             values['weight'] = 1.0
             values['storage_group_id'] = _get_storage_group_id_by_dev(osd_dev)
             values['zone_id'] = _get_zone_id()

--- a/source/vsm/vsm/agent/manager.py
+++ b/source/vsm/vsm/agent/manager.py
@@ -897,6 +897,65 @@ class AgentManager(manager.Manager):
         self.sync_osd_states_from_ceph(context)
         return True
 
+    def sync_osd_states_from_cluster(self, context):
+        def _determine_status(osd):
+            if osd['in'] and osd['up']:
+                osd_status = FLAGS.osd_in_up
+            elif osd['in'] and not osd['up']:
+                osd_status = FLAGS.osd_in_down
+            elif not osd['in'] and osd['up']:
+                osd_status = FLAGS.osd_out_up
+            else:
+                if FLAGS.osd_state_autoout in osd['state']:
+                    osd_status = FLAGS.osd_out_down_autoout
+                else:
+                    osd_status = FLAGS.osd_out_down
+            return osd_status
+
+        def _get_storage_hostnames(self):
+            server_list = db.init_node_get_all(context)
+            hostnames = [server['host'] for server in server_list]
+            return hostnames
+
+        def _get_local_osds_metadata():
+            md = self.ceph_driver.get_osds_metadata()
+            return filter(lambda osd: osd['hostname'] == self.host, md)
+
+        def _get_osd_detail_by_id(osd_num):
+            osds_det = self.ceph_driver.get_osds_details()
+            return filter(lambda osd: osd['osd'] == osd_num, osds_det)[0]
+
+        for osd_md in _get_local_osds_metadata():
+            osd_num = osd_md['id']
+            osd_det = _get_osd_detail_by_id(osd_num)
+            osd_name = 'osd.' + str(osd_num)
+
+            values = {}
+            values['osd_name'] = osd_name
+            values['state'] =  _determine_status(osd_det)
+            node = db.init_node_get_by_host(context , self.host)
+            values['service_id'] = node['service_id']
+            values['cluster_ip'] = osd_det['cluster_addr']
+            values['public_ip'] = osd_det['public_addr']
+
+            #device = db.device_get_by_name(context,config_dict.get(osd_name)["devs"])
+            #values['device_id'] = device["id"]
+
+            values['cluster_id'] = 1
+            values['weight'] = 1.0
+            values['storage_group_id'] = 1
+            values['zone_id'] = 1
+            values['operation_status'] = 'Present'
+
+            #self._conductor_rpcapi.\
+            #    osd_state_update_or_create(context, values)
+            print values
+
+            device_values = {}
+            device_values['mount_point'] = osd_md['osd_data']
+            #db.device_update(context, device["id"], device_values)
+        return
+
     def sync_osd_states_from_ceph(self, context):
         osd_json = self.ceph_driver.get_osds_status()
         config = cephconfigparser.CephConfigParser(FLAGS.ceph_conf)

--- a/source/vsm/vsm/agent/manager.py
+++ b/source/vsm/vsm/agent/manager.py
@@ -930,6 +930,10 @@ class AgentManager(manager.Manager):
             osds_det = self.ceph_driver.get_osds_details()
             return filter(lambda osd: osd['osd'] == osd_num, osds_det)[0]
 
+        def _extract_ip(report_ip_item):
+            items = report_ip_item.split(':')
+            return items[0]
+
         for osd_md in _get_local_osds_metadata():
             osd_num = osd_md['id']
             osd_det = _get_osd_detail_by_id(osd_num)
@@ -940,8 +944,8 @@ class AgentManager(manager.Manager):
             values['state'] = _determine_status(osd_det)
             node = db.init_node_get_by_host(context , self.host)
             values['service_id'] = node['service_id']
-            values['cluster_ip'] = osd_det['cluster_addr']
-            values['public_ip'] = osd_det['public_addr']
+            values['cluster_ip'] = _extract_ip(osd_det['cluster_addr'])
+            values['public_ip'] = _extract_ip(osd_det['public_addr'])
 
             #device = db.device_get_by_name(context,config_dict.get(osd_name)["devs"])
             #values['device_id'] = device["id"]

--- a/source/vsm/vsm/agent/manager.py
+++ b/source/vsm/vsm/agent/manager.py
@@ -947,22 +947,27 @@ class AgentManager(manager.Manager):
             values['cluster_ip'] = _extract_ip(osd_det['cluster_addr'])
             values['public_ip'] = _extract_ip(osd_det['public_addr'])
 
-            #device = db.device_get_by_name(context,config_dict.get(osd_name)["devs"])
-            #values['device_id'] = device["id"]
+            osd_dev = self.ceph_driver.get_dev_by_mpoint(osd_md['osd_data'])
+            try:
+                device = db.device_get_by_name(context, osd_dev)
+            except:
+                LOG.warn("Cannot find device %s. Skipping this OSD" % osd_dev)
+                continue
 
+            values['device_id'] = device['id']
             values['cluster_id'] = 1
             values['weight'] = 1.0
             values['storage_group_id'] = 1
             values['zone_id'] = 1
             values['operation_status'] = 'Present'
 
-            #self._conductor_rpcapi.\
-            #    osd_state_update_or_create(context, values)
+            self._conductor_rpcapi.\
+                osd_state_update_or_create(context, values)
             print values
 
             device_values = {}
             device_values['mount_point'] = osd_md['osd_data']
-            #db.device_update(context, device["id"], device_values)
+            db.device_update(context, device['id'], device_values)
         return
 
     def sync_osd_states_from_ceph(self, context):

--- a/source/vsm/vsm/agent/manager.py
+++ b/source/vsm/vsm/agent/manager.py
@@ -934,6 +934,16 @@ class AgentManager(manager.Manager):
             items = report_ip_item.split(':')
             return items[0]
 
+        def _get_storage_group_id_by_dev(device):
+            for sc in self._node_info["storage_class"]:
+                if any(disk['osd'] == device for disk in sc['disk']):
+                    storage_group = \
+                        db.storage_group_get_by_storage_class(self._context,
+                                                              sc['name'])
+                    return storage_group['id']
+            else:
+                return None
+
         for osd_md in _get_local_osds_metadata():
             osd_num = osd_md['id']
             osd_det = _get_osd_detail_by_id(osd_num)
@@ -957,7 +967,7 @@ class AgentManager(manager.Manager):
             values['device_id'] = device['id']
             values['cluster_id'] = 1
             values['weight'] = 1.0
-            values['storage_group_id'] = 1
+            values['storage_group_id'] = _get_storage_group_id_by_dev(osd_dev)
             values['zone_id'] = 1
             values['operation_status'] = 'Present'
 

--- a/source/vsm/vsm/agent/rpcapi.py
+++ b/source/vsm/vsm/agent/rpcapi.py
@@ -336,12 +336,28 @@ class AgentAPI(vsm.openstack.common.rpc.proxy.RpcProxy):
                         self.make_msg('cluster_refresh'),
                         topic, version='1.0', timeout=6000)
         return res
+
+    def integrate_cluster_update_status(self, context, host):
+        topic = rpc.queue_get_for(context, self.topic, host)
+        res = self.call(context,
+                        self.make_msg('integrate_cluster_update_status'),
+                        topic, version='1.0', timeout=6000)
+        return res
+
+    def integrate_cluster_sync_osd_states(self, context, host):
+        topic = rpc.queue_get_for(context, self.topic, host)
+        res = self.call(context,
+                        self.make_msg('integrate_cluster_sync_osd_states'),
+                        topic, version='1.0', timeout=6000)
+        return res
+
     def integrate_cluster_from_ceph(self, context, host):
         topic = rpc.queue_get_for(context, self.topic, host)
         res = self.call(context,
                         self.make_msg('integrate_cluster_from_ceph'),
                         topic, version='1.0', timeout=6000)
         return res
+
     def cluster_id(self, context, host):
         topic = rpc.queue_get_for(context, self.topic, host)
         res = self.call(context,

--- a/source/vsm/vsm/scheduler/manager.py
+++ b/source/vsm/vsm/scheduler/manager.py
@@ -1060,10 +1060,13 @@ class SchedulerManager(manager.Manager):
         :param server_list:
         :return:
         """
-        LOG.info('integrate cluster by refreshing cluster status')
+        LOG.info('integrate cluster by syncing OSDs and refreshing status')
+        server_list = db.init_node_get_all(context)
+        for srv in server_list:
+            self._agent_rpcapi.integrate_cluster_sync_osd_states(context, srv['host'])
         active_server = self._set_active_server(context)
         #TODO db.update_mount_points()
-        return self._agent_rpcapi.integrate_cluster_from_ceph(context, active_server['host'])
+        return self._agent_rpcapi.integrate_cluster_update_status(context, active_server['host'])
 
     @utils.single_lock
     def create_cluster(self, context, server_list):


### PR DESCRIPTION
This is PR is a part of wider efforts to bring support for integration of already existing Ceph clusters into VSM. The code provides ability  to grab information about a cluster without referring to its _ceph.conf_ and thus allows work with deployments realized through _ceph-deploy_ utility.

We still need:
* acquire information about CRUSH hierarchy and prepare appropriate structure of nested zones;
* map rulesets info storage groups.