### PR TITLE
add new function of revoke storage pool, only support restful api now

### DIFF
--- a/source/vsm/vsm/agent/driver.py
+++ b/source/vsm/vsm/agent/driver.py
@@ -2663,6 +2663,163 @@ class CephDriver(object):
         db.pool_update_by_name(context, storage_pool_name, cluster_id, {"cache_tier_status": None})
         return True
 
+    def auth_caps(self, context, entity, **kwargs):
+        """
+        update caps for <name> from caps specified in the command
+        :param context:
+        :param entity:
+        :param kwargs:
+        :return:
+        """
+
+        caps_keys = kwargs.keys()
+        if "mon" in caps_keys:
+            caps_mon = kwargs['mon']
+        else:
+            caps_mon = ""
+        if "osd" in caps_keys:
+            caps_osd = kwargs['osd']
+        else:
+            caps_osd = ""
+        if "mds" in caps_keys:
+            caps_mds = kwargs['mds']
+        else:
+            caps_mds = ""
+
+        try:
+            if caps_mon and caps_osd and caps_mds:
+                utils.execute('ceph', 'auth', 'caps', entity, 'mds', caps_mds,
+                              'mon', caps_mon, 'osd', caps_osd, run_as_root=True)
+            elif caps_mon and caps_osd:
+                utils.execute('ceph', 'auth', 'caps', entity, 'mon', caps_mon,
+                              'osd', caps_osd, run_as_root=True)
+            elif caps_mon:
+                utils.execute('ceph', 'auth', 'caps', entity, 'mon', caps_mon,
+                              run_as_root=True)
+        except:
+            LOG.error("Failed to update auth caps")
+            raise
+
+    def auth_get(self, context, entity):
+        """
+        get auth info
+        :param entity: client.ce1032ba-9ae9-4a7f-b456-f80fd821dd7f
+        :return:
+        {
+            "entity":"client.ce1032ba-9ae9-4a7f-b456-f80fd821dd7f",
+            "key":"AQB7Gp9WAP+tJRAAgvZTJJqJ\/GxHEL28a4DwLQ==",
+            "caps":{
+                "mon":"allow r",
+                "osd":"allow class-read object_prefix rbd_children,allow rwx pool=testpool01,allow rwx pool=testpool02"
+            }
+        }
+        """
+
+        out = utils.execute('ceph', 'auth', 'get', entity, '-f', 'plain',
+                               run_as_root=True)[0].strip("\n").split("\n")
+        result = {}
+        result["caps"] = {}
+        for line in out:
+            line = line.strip(" ")
+            if len(line.split("=")) < 2:
+                result["entity"] = line.replace("[","").replace("]","")
+            else:
+                if "key" in line.split("=")[0]:
+                    result["key"] = line.split("=")[1].strip()
+                elif "mon" in line.split("=")[0]:
+                    result["caps"]["mon"] = "=".join(line.split("=")[1:]).strip()[1:-1]
+                elif "osd" in line.split("=")[0]:
+                    result["caps"]["osd"] = "=".join(line.split("=")[1:]).strip()[1:-1]
+                elif "mds" in line.split("=")[0]:
+                    result["caps"]["mds"] = "=".join(line.split("=")[1:]).strip()[1:-1]
+
+        return result
+
+    def delete_cinder_type(self, context, name, **kwargs):
+        """
+
+        :param name: cinder type name
+        :param kwargs:
+        :return:
+        """
+
+        username = kwargs.pop('username')
+        password = kwargs.pop('password')
+        tenant_name = kwargs.pop('tenant_name')
+        auth_url = kwargs.pop('auth_url')
+        region_name = kwargs.pop('region_name')
+        cinderclient = cc.Client(username,
+                                 password,
+                                 tenant_name,
+                                 auth_url,
+                                 region_name=region_name)
+        cinder_type_list = cinderclient.volume_types.list()
+        delete_type = None
+        for type in cinder_type_list:
+            if type.name == name:
+                delete_type = type
+                break
+        if delete_type:
+            cinderclient.volume_types.delete(delete_type)
+        else:
+            LOG.warn("Not found the cinder type %s" % name)
+
+    def revoke_storage_pool_from_cinder_conf(self, context, auth_host,
+                                             cinder_host, ssh_user,
+                                             pool_name):
+        """
+
+        :param auth_host:
+        :param cinder_host:
+        :param ssh_user: ssh user
+        :param pool_name: pool name
+        :return:
+        """
+
+        line, err = utils.execute("su", "-s", "/bin/bash", "-c",
+                                  "exec ssh %s ssh %s sudo sed -n '/^enabled_backends/=' /etc/cinder/cinder.conf" %
+                                  (auth_host, cinder_host),
+                                  ssh_user, run_as_root=True)
+        line = line.strip(" ").strip("\n")
+        search_str = str(line) + "p"
+        enabled_backends, err = utils.execute("su", "-s", "/bin/bash", "-c",
+                                              "exec ssh %s ssh %s sudo sed -n %s /etc/cinder/cinder.conf" %
+                                              (auth_host, cinder_host, search_str),
+                                              ssh_user, run_as_root=True)
+        enabled_backends = enabled_backends.strip(" ").strip("\n")
+        backends_list = enabled_backends.split("=")[1].strip(" ").split(",")
+        new_backends_list = []
+        for backend in backends_list:
+            if backend != pool_name:
+                new_backends_list.append(backend)
+        new_enabled_backends = "enabled_backends\\\\\\ =\\\\\\ " + str(",".join(new_backends_list))
+        utils.execute("su", "-s", "/bin/bash", "-c",
+                      "exec ssh %s ssh %s sudo sed -i 's/^enabled_backends*.*/%s/g' /etc/cinder/cinder.conf" %
+                      (auth_host, cinder_host, new_enabled_backends),
+                      ssh_user, run_as_root=True)
+
+        search_str = '/rbd_pool\\\\\\ =\\\\\\ ' + pool_name + '/='
+        line, err = utils.execute("su", "-s", "/bin/bash", "-c",
+                                  "exec ssh %s ssh %s sudo sed -n \"%s\" /etc/cinder/cinder.conf" %
+                                  (auth_host, cinder_host, search_str),
+                                  ssh_user, run_as_root=True)
+        line = line.strip(" ").strip("\n")
+        # remove 10 lines total
+        start_line = int(line) - 2
+        line_after = 9
+        end_line = int(start_line) + line_after
+        utils.execute("su", "-s", "/bin/bash", "-c",
+                      "exec ssh %s ssh %s sudo sed -i %s','%s'd' /etc/cinder/cinder.conf" %
+                      (auth_host, cinder_host, start_line, end_line), ssh_user,
+                      run_as_root=True)
+        try:
+            utils.execute("service", "cinder-api", "restart", run_as_root=True)
+            utils.execute("service", "cinder-volume", "restart", run_as_root=True)
+            LOG.info("Restart cinder-api and cinder-volume successfully")
+        except:
+            utils.execute("service", "openstack-cinder-api", "restart", run_as_root=True)
+            utils.execute("service", "openstack-cinder-volume", "restart", run_as_root=True)
+            LOG.info("Restart openstack-cinder-api and openstack-cinder-volume successfully")
 
 class DbDriver(object):
     """Executes commands relating to TestDBs."""

--- a/source/vsm/vsm/agent/rpcapi.py
+++ b/source/vsm/vsm/agent/rpcapi.py
@@ -56,6 +56,9 @@ class AgentAPI(vsm.openstack.common.rpc.proxy.RpcProxy):
     def present_storage_pools(self, context, body=None):
         return self.cast(context, self.make_msg('present_storage_pools', body=body))
 
+    def revoke_storage_pool(self, context, id):
+        return self.call(context, self.make_msg('revoke_storage_pool', id=id))
+
     def update_keyring_admin_from_db(self, context, host):
         topic = rpc.queue_get_for(context, self.topic, host)
         return self.call(context,

--- a/source/vsm/vsm/api/v1/router.py
+++ b/source/vsm/vsm/api/v1/router.py
@@ -42,6 +42,7 @@ from vsm.api.v1 import vsm_settings
 from vsm.api.v1 import vsms
 from vsm.api.v1 import licenses
 from vsm.api.v1 import performance_metrics
+from vsm.api.contrib import poolusages
 
 from vsm.openstack.common import log as logging
 
@@ -234,4 +235,10 @@ class APIRouter(vsm.api.openstack.APIRouter):
                         collection={"get_list": "get",
                                     "get_metrics": "get",
                                     },
+                        member={'action':'post'})
+
+        self.resources['poolusages'] = poolusages.create_resource(ext_mgr)
+        mapper.resource("poolusages", "poolusages",
+                        controller=self.resources['poolusages'],
+                        collection={'revoke_pool': "post"},
                         member={'action':'post'})

--- a/source/vsm/vsm/conductor/api.py
+++ b/source/vsm/vsm/conductor/api.py
@@ -49,6 +49,9 @@ class API(object):
     def list_storage_pool(self, context):
         return self.conductor_rpcapi.list_storage_pool(context)
 
+    def get_storage_pool(self, context, id):
+        return self.conductor_rpcapi.get_storage_pool(context, id)
+
     def get_storage_group_list(self, context):
         return self.conductor_rpcapi.get_storage_group_list(context)
 
@@ -307,3 +310,6 @@ class API(object):
 
     def get_cpu_usage(self, context, search_opts):
         return self.conductor_rpcapi.get_cpu_usage(context, search_opts)
+
+    def get_poolusage(self, context, poolusage_id):
+        return self.conductor_rpcapi.get_poolusage(context, poolusage_id)

--- a/source/vsm/vsm/conductor/manager.py
+++ b/source/vsm/vsm/conductor/manager.py
@@ -98,6 +98,10 @@ class ConductorManager(manager.Manager):
 
         return pool_list_dict
 
+    def get_storage_pool(self, context, id):
+        LOG.info('get_storage_pool in conductor manager')
+        return db.pool_get_by_db_id(context, id)
+
     def destroy_storage_pool(self, context, pool_name):
         if pool_name:
             db.pool_destroy(context, pool_name)
@@ -623,3 +627,12 @@ class ConductorManager(manager.Manager):
 
     def get_cpu_usage(self, context, search_opts):
         return db.get_cpu_usage(context, search_opts=search_opts)
+
+    def get_poolusage(self, context, poolusage_id):
+        return db.get_poolusage(context, poolusage_id=poolusage_id)
+
+    def get_appnode(self, context, appnode_id):
+        return db.appnodes_get_by_id(context, appnode_id)
+
+    def delete_pool_usage(self, context, poolusage_id):
+        return db.destroy_storage_pool_usage(context, poolusage_id)

--- a/source/vsm/vsm/conductor/rpcapi.py
+++ b/source/vsm/vsm/conductor/rpcapi.py
@@ -47,6 +47,11 @@ class ConductorAPI(vsm.openstack.common.rpc.proxy.RpcProxy):
         ret = self.call(ctxt, self.make_msg('list_storage_pool'))
         return ret
 
+    def get_storage_pool(self, ctxt, id):
+        ret = self.call(ctxt, self.make_msg('get_storage_pool',
+                                            id=id))
+        return ret
+
     def destroy_storage_pool(self, ctxt, pool_name):
         self.cast(ctxt, self.make_msg('destroy_storage_pool', pool_name=pool_name))
 
@@ -404,3 +409,15 @@ class ConductorAPI(vsm.openstack.common.rpc.proxy.RpcProxy):
     def get_cpu_usage(self, context, search_opts):
         return self.call(context,self.make_msg('get_cpu_usage', \
                                search_opts=search_opts))
+
+    def get_poolusage(self, context, poolusage_id):
+        return self.call(context, self.make_msg('get_poolusage',
+                                                poolusage_id=poolusage_id))
+
+    def get_appnode(self, context, appnode_id):
+        return self.call(context, self.make_msg('get_appnode',
+                                                appnode_id=appnode_id))
+
+    def delete_pool_usage(self, context, poolusage_id):
+        return self.call(context, self.make_msg('delete_pool_usage',
+                                                poolusage_id=poolusage_id))

--- a/source/vsm/vsm/db/api.py
+++ b/source/vsm/vsm/db/api.py
@@ -774,6 +774,9 @@ def pool_get_all(context):
 def pool_get(context, pool_id):
     return IMPL.pool_get(context, pool_id)
 
+def pool_get_by_db_id(context, id):
+    return IMPL.pool_get_by_db_id(context, id)
+
 def pool_get_by_name(context, pool_name, cluster_id):
     return IMPL.pool_get_by_name(context, pool_name, cluster_id)
 
@@ -1284,4 +1287,7 @@ def get_cpu_usage(context, search_opts):
 
 def clean_performance_history_data(context,days):
     return IMPL.clean_performance_history_data(context,days)
+
+def get_poolusage(context, poolusage_id):
+    return IMPL.get_poolusage(context, poolusage_id=poolusage_id)
 #endregion

--- a/source/vsm/vsm/db/sqlalchemy/api.py
+++ b/source/vsm/vsm/db/sqlalchemy/api.py
@@ -4273,3 +4273,10 @@ def clean_performance_history_data(context,days):
     timestamp = time.time() - int(days) * 24 * 3600
     sql_str = 'delete from metrics where timestamp<%s'%timestamp
     session.execute(sql_str)
+
+def get_poolusage(context, poolusage_id):
+    result = model_query(
+        context, models.StoragePoolUsage).\
+        filter_by(id=poolusage_id).\
+        first()
+    return result

--- a/source/vsm/vsm/db/sqlalchemy/models.py
+++ b/source/vsm/vsm/db/sqlalchemy/models.py
@@ -559,6 +559,7 @@ class StoragePool(BASE, VsmBase):
     primary_storage_group_id = Column(Integer, ForeignKey('storage_groups.id'), nullable=False)
     storage_group = relationship(StorageGroup,
                            backref=backref('storage_pool'),
+                           lazy='subquery',
                            foreign_keys=primary_storage_group_id,
                            primaryjoin='and_('
                            'StoragePool.primary_storage_group_id == StorageGroup.id,'

--- a/source/vsm/vsm/scheduler/api.py
+++ b/source/vsm/vsm/scheduler/api.py
@@ -45,6 +45,9 @@ class API(object):
     def present_storage_pools(self, context, body=None):
         return self.scheduler_rpcapi.present_storage_pools(context, body)
 
+    def revoke_storage_pool(self, context, id):
+        return self.scheduler_rpcapi.revoke_storage_pool(context, id)
+
     def get_storage_group_list(self, context):
         return self.scheduler_rpcapi.get_storage_group_list(context)
 

--- a/source/vsm/vsm/scheduler/manager.py
+++ b/source/vsm/vsm/scheduler/manager.py
@@ -84,6 +84,10 @@ class SchedulerManager(manager.Manager):
         LOG.info('scheduler/manager.py present_storage_pools')
         return self._agent_rpcapi.present_storage_pools(context, body)
 
+    def revoke_storage_pool(self, context, id):
+        LOG.info('scheduler/manager.py revoke_storage_pool')
+        self._agent_rpcapi.revoke_storage_pool(context, id)
+
     def create_storage_pool(self, context, body=None,cluster_id = None):
         LOG.info('scheduler/manager.py create_storage_pool')
         active_monitor = self._get_active_monitor(context, cluster_id=cluster_id)

--- a/source/vsm/vsm/scheduler/rpcapi.py
+++ b/source/vsm/vsm/scheduler/rpcapi.py
@@ -64,6 +64,9 @@ class SchedulerAPI(vsm.openstack.common.rpc.proxy.RpcProxy):
         ret = self.cast(ctxt, self.make_msg('present_storage_pools', body=body))
         return ret
 
+    def revoke_storage_pool(self, ctxt, id):
+        self.call(ctxt, self.make_msg('revoke_storage_pool', id=id))
+
     def get_storage_group_list(self, ctxt):
         ret = self.call(ctxt, self.make_msg('get_storage_group_list'))
         return ret


### PR DESCRIPTION
1. change the cinder.conf file, remove the storage pool of enabled_backends
2. delete the cinder type of this storage pool
3. update auth caps, remove the storage pool from osd
4. remove the poolusage from the db, set the deleted with "1"