### PR TITLE
Enhance uninstall to be option-driven and more maintainable.

### DIFF
--- a/ubuntu14/uninstall.sh
+++ b/ubuntu14/uninstall.sh
@@ -15,8 +15,32 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# Defaults
+REMOVE_CEPH_PKGS=1
 
-#!/bin/bash
+# Parse command line options to change defaults
+OPTIND=1
+while getopts "h?kc" opt; do
+    case "$opt" in
+    h|\?)
+        echo "Uninstall VSM and other components and clean up any remaining file system items and processes."
+        echo "By default: Uninstall VSM, RabbitMQ, Diamond, and Ceph components."
+	echo "By default: Do NOT uninstall Keystone components.
+        echo ""
+        echo "Usage: uninstall.sh [options]"
+        echo "options:"
+        echo "   -k  Uninstall Keystone components."
+        echo "   -c  Suppress removal of Ceph cluster and components."
+        exit 0
+        ;;
+    k)  REMOVE_KEYSTONE_PKGS=1
+        ;;
+    c)  unset REMOVE_CEPH_PKGS
+        ;;
+    esac
+done
+
+set -o xtrace
 
 TOPDIR=$(cd $(dirname "$0") && pwd)
 USER=`whoami`
@@ -24,10 +48,43 @@ USER=`whoami`
 source $TOPDIR/installrc
 
 for ip in $CONTROLLER_ADDRESS; do
-    ssh -t $ip "sudo clean-data -f; sudo service vsm-api stop; sudo service vsm-scheduler stop; sudo service vsm-conductor stop; sudo service mysql restart; sudo service rabbitmq-server restart; sleep 3; sudo apt-get remove --yes vsm vsm-dashboard python-vsmclient vsm-deploy; sudo apt-get autoclean --yes"
+    ssh -t $ip 'bash -x -s' <<EOF
+if [ -n "${REMOVE_CEPH_PKGS}" ]; then
+    sudo clean-data -f
+fi
+sudo service vsm-api stop
+sudo service vsm-scheduler stop
+sudo service vsm-conductor stop
+sudo service mysql restart
+sudo service rabbitmq-server restart
+sleep 3
+sudo apt-get purge --yes vsm vsm-dashboard python-vsmclient vsm-deploy
+sudo apt-get purge --yes rabbitmq-server librabbitmq1
+sudo killall rabbitmq-server beam.smp
+sudo apt-get purge --yes diamond
+if [ -n "${REMOVE_KEYSTONE_PKGS}" ]; then
+    sudo apt-get purge --yes keystone python-keystone python-keystoneclient python-keystonemiddleware
+    sudo rm -rf /var/lib/keystone /etc/keystone
+fi
+sudo apt-get autoremove --yes
+sudo apt-get autoclean --yes
+sudo rm -rf /etc/vsm /etc/vsm-dashboard /etc/vsmdeploy /var/lib/vsm /var/log/vsm
+EOF
 done
 
 for ip in $AGENT_ADDRESS_LIST; do
-    ssh -t $ip "sudo clean-data -f; sudo service vsm-agent stop; sudo service vsm-physical stop; sudo apt-get remove --yes vsm vsm-dashboard python-vsmclient vsm-deploy; sudo apt-get autoclean --yes"
+    ssh -t $ip 'bash -x -s' <<EOF
+if [ -n "${REMOVE_CEPH_PKGS}" ]; then
+    sudo clean-data -f
+fi
+sudo service vsm-agent stop
+sudo service vsm-physical stop
+sudo apt-get purge --yes vsm vsm-dashboard python-vsmclient vsm-deploy
+sudo apt-get purge --yes diamond
+sudo apt-get purge --yes python-keystoneclient
+sudo apt-get autoremove --yes
+sudo apt-get autoclean --yes
+sudo rm -rf /var/lib/vsm /var/log/vsm /etc/vsm
+EOF
 done
 

--- a/ubuntu14/uninstall.sh
+++ b/ubuntu14/uninstall.sh
@@ -25,7 +25,7 @@ while getopts "h?kc" opt; do
     h|\?)
         echo "Uninstall VSM and other components and clean up any remaining file system items and processes."
         echo "By default: Uninstall VSM, RabbitMQ, Diamond, and Ceph components."
-	echo "By default: Do NOT uninstall Keystone components.
+        echo "By default: Do NOT uninstall Keystone components.
         echo ""
         echo "Usage: uninstall.sh [options]"
         echo "options:"


### PR DESCRIPTION
Hi Yaguang - here's the updated ubuntu14 uninstall.sh I mentioned in http://vsm-discuss.33411.n7.nabble.com/rabbitmq-not-getting-removed-during-uninstall-sh-tp379.html. This version is 100% backward compatible with the existing version, but these command-line options are available in this version:

\-k - uninstall keystone components
\-c - suppress removal of ceph cluster and components

It would be nice not to have one of them be an inverse option, but the original removed the ceph cluster and packages, and we're using vsm to manage an imported cluster. We need the -c option to suppress default behavior.