### PR TITLE
Updated to optionally remove apache2 and mariadb/mysql; parallelize agent uninstall.

### DIFF
--- a/ubuntu14/uninstall.sh
+++ b/ubuntu14/uninstall.sh
@@ -20,20 +20,28 @@ REMOVE_CEPH_PKGS=1
 
 # Parse command line options to change defaults
 OPTIND=1
-while getopts "h?kc" opt; do
+while getopts "h?kmac" opt; do
     case "$opt" in
     h|\?)
         echo "Uninstall VSM and other components and clean up any remaining file system items and processes."
         echo "By default: Uninstall VSM, RabbitMQ, Diamond, and Ceph components."
+        echo "By default: Do NOT uninstall MySQL/MariaDB components."
+        echo "By default: Do NOT uninstall Apache2 server components."
         echo "By default: Do NOT uninstall Keystone components."
         echo ""
         echo "Usage: uninstall.sh [options]"
         echo "options:"
         echo "   -k  Uninstall Keystone components."
+        echo "   -m  Uninstall MySQL/MariaDB components."
+        echo "   -a  Uninstall Apache2 server components."
         echo "   -c  Suppress removal of Ceph cluster and components."
         exit 0
         ;;
     k)  REMOVE_KEYSTONE_PKGS=1
+        ;;
+    m)  REMOVE_MYSQL_PKGS=1
+        ;;
+    a)  REMOVE_APACHE2_PKGS=1
         ;;
     c)  unset REMOVE_CEPH_PKGS
         ;;
@@ -47,16 +55,18 @@ USER=`whoami`
 
 source $TOPDIR/installrc
 
-for ip in $CONTROLLER_ADDRESS; do
-    ssh -t $ip 'bash -x -s' <<EOF
+function uninstall_controller()
+{
+    echo "=== Uninstall controller [$1] start."
+    ssh -t $1 'bash -x -s' <<EOF
 if [ -n "${REMOVE_CEPH_PKGS}" ]; then
     sudo clean-data -f
 fi
 sudo service vsm-api stop
 sudo service vsm-scheduler stop
 sudo service vsm-conductor stop
-sudo service mysql restart
-sudo service rabbitmq-server restart
+test -d /etc/mysql && sudo service mysql restart
+test -d /etc/rabbitmq && sudo service rabbitmq-server restart
 sleep 3
 sudo apt-get purge --yes vsm vsm-dashboard python-vsmclient vsm-deploy
 sudo apt-get purge --yes rabbitmq-server librabbitmq1
@@ -66,14 +76,29 @@ if [ -n "${REMOVE_KEYSTONE_PKGS}" ]; then
     sudo apt-get purge --yes keystone python-keystone python-keystoneclient python-keystonemiddleware
     sudo rm -rf /var/lib/keystone /etc/keystone
 fi
+if [ -n "${REMOVE_MYSQL_PKGS}" ]; then
+    sudo apt-get purge --yes mariadb-client-5.5 mariadb-client-core-5.5
+    sudo apt-get purge --yes mariadb-server mariadb-server-5.5 mariadb-server-core-5.5
+    sudo apt-get purge --yes libdbd-mysql-perl libmysqlclient18:amd64 mysql-common python-mysqldb
+    sudo killall mysqld
+    sudo rm -rf /etc/mysql /var/lib/mysql
+fi
+if [ -n "${REMOVE_APACHE2_PKGS}" ]; then
+    sudo apt-get purge --yes apache2 apache2-bin apache2-data libapache2-mod-wsgi
+    sudo killall apache2
+    sudo rm -rf /etc/apache2
+fi
 sudo apt-get autoremove --yes
 sudo apt-get autoclean --yes
 sudo rm -rf /etc/vsm /etc/vsm-dashboard /etc/vsmdeploy /var/lib/vsm /var/log/vsm
 EOF
-done
+    echo "=== Uninstall controller [$1] complete."
+}
 
-for ip in $AGENT_ADDRESS_LIST; do
-    ssh -t $ip 'bash -x -s' <<EOF
+function uninstall_agent()
+{
+echo "=== Uninstall agent [$1] start."
+    ssh -t $1 'bash -x -s' <<EOF
 if [ -n "${REMOVE_CEPH_PKGS}" ]; then
     sudo clean-data -f
 fi
@@ -82,9 +107,27 @@ sudo service vsm-physical stop
 sudo apt-get purge --yes vsm vsm-dashboard python-vsmclient vsm-deploy
 sudo apt-get purge --yes diamond
 sudo apt-get purge --yes python-keystoneclient
+if [ -n "${REMOVE_MYSQL_PKGS}" ]; then
+    sudo apt-get purge --yes libdbd-mysql-perl libmysqlclient18:amd64 mysql-common python-mysqldb
+    sudo rm -rf /etc/mysql
+fi
 sudo apt-get autoremove --yes
 sudo apt-get autoclean --yes
 sudo rm -rf /var/lib/vsm /var/log/vsm /etc/vsm
 EOF
+    echo "=== Uninstall agent [$1] complete."
+}
+
+# remove controller in the foreground
+uninstall_controller $CONTROLLER_ADDRESS
+
+# remove all agents simultaneously; wait for all to finish
+for ip in $AGENT_ADDRESS_LIST; do
+    tf=$(mktemp)
+    tf_list="${tf_list} ${tf}"
+    echo "=== Starting asynchronous agent uninstall [$ip] ..."
+    uninstall_agent $ip >${tf} 2>&1 &
 done
+wait
+for tf in ${tf_list}; do cat ${tf}; rm -f ${tf}; done
 


### PR DESCRIPTION
This change to ubuntu14 uninstall.sh (only) enhances uninstall to optionally remove all installed components (newly added to uninstall are mariadb/mysql, and apache2). It also parallelizes agent uninstall so all agents are uninstall together. As with the install changes I made on a different pull request, these background processes save stdout and stderr to temporary files, which are then cat'd serially to stdout after all background processes have completed.