### PR TITLE
fix diamond default interval issue and 2 log info of conductor

### DIFF
--- a/source/vsm/vsm/conductor/manager.py
+++ b/source/vsm/vsm/conductor/manager.py
@@ -154,7 +154,7 @@ class ConductorManager(manager.Manager):
         return self._set_error(context)
 
     def get_cluster_list(self, context):
-        LOG.info('get_server_list in conductor manager')
+        LOG.info('get_cluster_list in conductor manager')
         cluster_list = db.init_node_get_all(context)
         ret = self._set_error(context)
         for ser in cluster_list:
@@ -163,7 +163,7 @@ class ConductorManager(manager.Manager):
         return cluster_list
 
     def get_server(self, context, id):
-        LOG.info('get_server_list in conductor manager')
+        LOG.info('get_server in conductor manager')
         server = db.init_node_get(context, id)
         ret = self._set_error(context)
         if ret:

--- a/source/vsm/vsm/flags.py
+++ b/source/vsm/vsm/flags.py
@@ -506,10 +506,10 @@ vsm_settings_opts = [
                default=60,
                help='ceph mds dump (secs)'),
     cfg.IntOpt('cpu_diamond_collect_interval',
-               default=0,
+               default=15,
                help='cpu data collect interval (secs) with diamond'),
     cfg.IntOpt('ceph_diamond_collect_interval',
-               default=0,
+               default=15,
                help='ceph perf data collect interval (secs) with diamond'),
     cfg.IntOpt('keep_performance_data_days',
            default=7,
@@ -517,3 +517,4 @@ vsm_settings_opts = [
 ]
 
 FLAGS.register_opts(vsm_settings_opts)
+


### PR DESCRIPTION
1、Changed the diamond default interval db settings from 0s to 15s
2、fix 2 log info typos of conductor manager