### PR TITLE
Ensure get_storage_group_and_class_list always returns a proper set o…

### DIFF
--- a/source/vsm/vsm/api/v1/agents.py
+++ b/source/vsm/vsm/api/v1/agents.py
@@ -434,7 +434,8 @@ class AgentsController(wsgi.Controller):
                 value['rule_id'] = item['rule_id']
                 value['storage_class'] = item['storage_class']
                 storage_group_list.append(value)
-                storage_class_list.append(item['storage_class'])
+                if not item['storage_class'] in storage_class_list:
+                    storage_class_list.append(item['storage_class'])
         return storage_group_list, storage_class_list
 
     @wsgi.serializers(xml=AgentsTemplate)


### PR DESCRIPTION
Hi Yaguang, we found that when we have more than one storage group that refers to the same storage class, that storage class can be returned more then once in the list returned by AgentsController:get_storage_group_and_class_list. This, in turn causes cluster import to fail because the import routine attempts to assign all OSDs set to the duplicated storage class multiple times. This change just ensures that get_storage_group_and_class_list always returns a proper set of storage class names.