### PR TITLE
Ensure various installation scripts cleanup properly - even on error.

### DIFF
--- a/ubuntu14/vsm-deploy/vsm-installer
+++ b/ubuntu14/vsm-deploy/vsm-installer
@@ -19,12 +19,20 @@
 set -e
 set -o xtrace
 
+# setup an EXIT trap; restore original ssh_config on script exit (even if there was no original)
+function cleanup()
+{
+    test -f /etc/ssh/ssh_config.vsmsave && mv /etc/ssh/ssh_config.vsmsave /etc/ssh/ssh_config || rm /etc/ssh/ssh_config
+}
+trap cleanup EXIT
+
+# replace ssh_config with temporary version; replace on exit by calling cleanup as EXIT handler
+test -f /etc/ssh/ssh_config && mv /etc/ssh/ssh_config /etc/ssh/ssh_config.vsmsave
 cat <<"EOF" > /etc/ssh/ssh_config
 UserKnownHostsFile /dev/null
 ConnectTimeout 15
 StrictHostKeyChecking no
 EOF
-service ssh restart
 
 #---------------------------------------------
 # Setup Variable.

--- a/ubuntu14/vsm-deploy/vsm-node
+++ b/ubuntu14/vsm-deploy/vsm-node
@@ -19,12 +19,20 @@
 set -e
 set -o xtrace
 
+# setup an EXIT trap; restore original ssh_config on script exit (even if there was no original)
+function cleanup()
+{
+    test -f /etc/ssh/ssh_config.vsmsave && mv /etc/ssh/ssh_config.vsmsave /etc/ssh/ssh_config || rm /etc/ssh/ssh_config
+}
+trap cleanup EXIT
+
+# replace ssh_config with temporary version; replace on exit by calling cleanup as EXIT handler
+test -f /etc/ssh/ssh_config && mv /etc/ssh/ssh_config /etc/ssh/ssh_config.vsmsave
 cat <<"EOF" > /etc/ssh/ssh_config
 UserKnownHostsFile /dev/null
 ConnectTimeout 15
 StrictHostKeyChecking no
 EOF
-service ssh restart
 
 TOPDIR=$(cd $(dirname "$0") && pwd)
 TEMP=`mktemp`; rm -rfv $TEMP >/dev/null; mkdir -p $TEMP;


### PR DESCRIPTION
Hi Yaguang. This change set adds exit traps to various shell scripts used during vsm installation to ensure that important files that get renamed or moved end up back where they're supposed to be on exit. (Also note, that you don't have to restart the ssh daemon when you make changes to the ssh_config file - that file is only used by the ssh client; so I removed the ssh restart command.)