### PR TITLE
Ensure mount attr returns a proper default value.

### DIFF
--- a/source/vsm/vsm/agent/cephconfigparser.py
+++ b/source/vsm/vsm/agent/cephconfigparser.py
@@ -232,7 +232,7 @@ class CephConfigParser(manager.Manager):
         parser = Parser()
         parser.read(FLAGS.ceph_conf)
         fs_type = parser.get('osd', 'osd mkfs type', 'xfs')
-        mount_attr = parser.get('osd', 'osd mount options %s' % fs_type)
+        mount_attr = parser.get('osd', 'osd mount options %s' % fs_type, utils.get_fs_options(fs_type))
 
         for sec in parser.sections():
             if sec.find('osd.') != -1:


### PR DESCRIPTION
This change ensures that load_ceph_conf_from_db returns a proper default value for mount_attr. Without this change, vsm will fail to run operations that require mount attr if that value is not specified in the conf file.