### PR TITLE
Allow unicode strings from protocol buffers to be used as file names during import.

### DIFF
--- a/source/vsm/vsm/agent/cephconfigparser.py
+++ b/source/vsm/vsm/agent/cephconfigparser.py
@@ -254,7 +254,7 @@ class CephConfigParser(manager.Manager):
 
         try:
             if not fp is None:
-                if isinstance(fp, str):
+                if isinstance(fp, str) or isinstance(fp, unicode):
                     if os.path.exists(fp) and os.path.isfile(fp):
                         self._parser.read(fp)
                 elif isinstance(fp, dict):


### PR DESCRIPTION
This change allows the unicode strings found in rest protocol buffers to be used as string values in the ceph configuration parser. Without this change, the file name specified by the user in the import_ceph_cluster script will not be treated like a string and the ceph config file will not be imported.