### PR TITLE
Cleanup installer; ensure all arguments work correctly.

### DIFF
--- a/ubuntu14/install.sh
+++ b/ubuntu14/install.sh
@@ -24,35 +24,48 @@ function usage() {
 Usage: install.sh
 
 Auto deploy vsm:
-    The tool can help you to deploy the vsm envirement automatically.
+    This tool can help you deploy the vsm envirement automatically.
     Please run the command like: bash +x install.sh or ./install.sh
+
+    Before auto-deploying VSM, please be sure that you have set up
+    the manifests, and that you've modified them appropriately.
+    For example:
+        manifest
+            192.168.100.100
+                cluster.manifest
+            192.168.100.101
+                server.manifest
 
 Options:
   --help | -h
     Print usage information.
   --manifest [manifest directory] | -m [manifest directory]
-    The directory to store the server.manifest and cluster.manifest.
+    The directory in which to find server and cluster manifests.
   --repo-path [dependencies path]
-    The path of dependencies.
+    The path of package dependencies.
   --version [master] | -v [master]
     The version of vsm dependences to download(Default=master).
   --key [key file] | -k [key file]
     The key file required for ssh/scp connection at the environment
-  where certificate based authentication is enabled.
+    where certificate based authentication is enabled.
   --user | -u
-    The user will be used to connect remote nodes to deploy vsm.
+    The user to be used when connecting to remote nodes to deploy vsm.
   --prepare
-    Preparing to install vsm. Checking vsm packages, downloading
-  the dependencies and setting the repository.
+    Run prepare stage only. Check vsm packages, download
+    package dependencies and set up the package repository.
   --controller [ip or hostname]
-    Installing the controller node only.
+    Run controller installation only.
   --agent [ip,ip or hostname]
-    Install the agent node(s), like: --agent ip,ip or hostname with no blank.
+    Run agent installation only - e.g., --agent ip,ip or hostname with no blank.
   --check-dependence-package
-    Check the dependence package if provided the dependence repo.
+    Check the dependent packages, assuming the dependence repo exists.
 EOF
     exit 0
 }
+
+#-------------------------------------------------------------------------------
+#            command-line parsing
+#-------------------------------------------------------------------------------
 
 MANIFEST_PATH=""
 REPO_PATH="vsm-dep-repo"
@@ -64,8 +77,8 @@ SUDO='sudo -E'
 IS_PREPARE=False
 IS_CONTROLLER_INSTALL=False
 IS_AGENT_INSTALL=False
-NEW_CONTROLLER_ADDRESS=""
-NEW_AGENT_IPS=""
+CONTROLLER_IP=""
+AGENT_IPS=""
 IS_CHECK_DEPENDENCE_PACKAGE=False
 
 while [ $# -gt 0 ]; do
@@ -77,27 +90,21 @@ while [ $# -gt 0 ]; do
     -u| --user) shift; USER=$1 ;;
     -k| --key) shift; keyfile=$1; export SSH='ssh -i $keyfile'; export SCP='scp -i $keyfile' ;;
     --prepare) IS_PREPARE=True ;;
-    --controller) shift; IS_CONTROLLER_INSTALL=True; NEW_CONTROLLER_ADDRESS=$1 ;;
-    --agent) shift; IS_AGENT_INSTALL=True; NEW_AGENT_IPS=$1 ;;
+    --controller) shift; IS_CONTROLLER_INSTALL=True; CONTROLLER_IP=$1 ;;
+    --agent) shift; IS_AGENT_INSTALL=True; AGENT_IPS=${1//,/ } ;;
     --check-dependence-package) shift; IS_CHECK_DEPENDENCE_PACKAGE=True ;;
     *) shift ;;
   esac
   shift
 done
 
-
 set -e
 set -o xtrace
-
-echo "Before auto deploy the vsm, please be sure that you have set the manifest 
-such as manifest/192.168.100.100/server.manifest. And you have changed the file, too."
-sleep 5
 
 TOPDIR=$(cd $(dirname "$0") && pwd)
 TEMP=`mktemp`; rm -rfv $TEMP >/dev/null; mkdir -p $TEMP;
 
 HOSTNAME=`hostname`
-#HOSTIP=`hostname -I|sed s/[[:space:]]//g`
 HOSTIP=`hostname -I`
 
 source $TOPDIR/installrc
@@ -106,38 +113,42 @@ if [ -z $MANIFEST_PATH ]; then
     MANIFEST_PATH="manifest"
 fi
 
-if [[ $NEW_CONTROLLER_ADDRESS != "" ]]; then
-    CONTROLLER_ADDRESS=$NEW_CONTROLLER_ADDRESS
+# if no specific installation type was requested, turn them all on
+if [[ $IS_PREPARE == False ]] && [[ $IS_CONTROLLER_INSTALL == False ]]\
+    && [[ $IS_AGENT_INSTALL == False ]]; then
+    IS_PREPARE=True
+    IS_CONTROLLER_INSTALL=True
+    IS_AGENT_INSTALL=True
 fi
 
-function _make_me_super() { # _make_me_super <user> <node>
-    MKMESUPER="$1 ALL=(ALL) NOPASSWD: ALL"
-    $SSH $USER@$2 "$SUDO echo '$MKMESUPER' | $SUDO tee /etc/sudoers.d/$1; $SUDO chmod 0440 /etc/sudoers.d/$1"
-}
+if [[ $CONTROLLER_IP == "" ]]; then
+    CONTROLLER_IP=$CONTROLLER_ADDRESS
+fi
 
-# enable no-password sudo
-_make_me_super $USER $CONTROLLER_ADDRESS
-
-for node in $AGENT_ADDRESS_LIST; do
-    _make_me_super $USER $node
-done
+if [[ $AGENT_IPS == "" ]]; then
+    AGENT_IPS=$AGENT_ADDRESS_LIST
+fi
 
 IS_CONTROLLER=0
 for ip in $HOSTIP; do
-    if [ $ip == $CONTROLLER_ADDRESS ]; then
+    if [ $ip == $CONTROLLER_IP ]; then
         IS_CONTROLLER=1
     fi
 done
 
-if [[ $HOSTNAME == $CONTROLLER_ADDRESS ]]; then
+if [[ $HOSTNAME == $CONTROLLER_IP ]]; then
     IS_CONTROLLER=1
 fi
 
 if [ $IS_CONTROLLER -eq 0 ]; then
-    echo "[Info]: You run the tool in a third server."
+    echo "[Info]: Running installer on non-cluster server."
 else
-    echo "[Info]: You run the tool in the controller server."
+    echo "[Info]: Running installer on the controller server."
 fi
+
+#-------------------------------------------------------------------------------
+#            exit handling
+#-------------------------------------------------------------------------------
 
 declare -a on_exit_items
 function on_exit()
@@ -160,6 +171,25 @@ function add_on_exit()
 #            prepare
 #-------------------------------------------------------------------------------
 
+# make_me_super <user> <node>
+function make_me_super() {
+    MKMESUPER="$1 ALL=(ALL) NOPASSWD: ALL"
+    if [[ $IS_CONTROLLER -eq 1 && $2 == $CONTROLLER_IP ]]; then
+        if ! $SUDO -n true; then
+            $SUDO echo '$MKMESUPER' | $SUDO tee /etc/sudoers.d/$1
+            $SUDO chmod 0440 /etc/sudoers.d/$1
+        fi
+    else
+        $SSH $USER@$2 "bash -x -s" <<EOF
+if ! $SUDO -n true; then
+    $SUDO echo '$MKMESUPER' | $SUDO tee /etc/sudoers.d/$1
+    $SUDO chmod 0440 /etc/sudoers.d/$1
+fi
+exit 0
+EOF
+    fi
+}
+
 function check_vsm_package() {
     if [[ ! -d vsmrepo ]]; then
         echo "You must have the vsmrepo folder, please check and try again."
@@ -180,11 +210,14 @@ function check_vsm_package() {
     cd $TOPDIR
 }
 
-function set_iptables_and_selinux() {
-    $SSH $USER@$1 "service iptables stop"
-    $SSH $USER@$1 "chkconfig iptables off"
-    $SSH $USER@$1 "sed -i \"s/SELINUX=enforcing/SELINUX=disabled/g\" /etc/selinux/config"
-    $SSH $USER@$1 "setenforce 0"
+function set_iptables_and_selinux() { # set_iptables_and_selinux <node>
+    $SSH $USER@$1 "bash -x -s" <<EOF
+service iptables stop
+chkconfig iptables off
+sed -i "s/SELINUX=enforcing/SELINUX=disabled/g" /etc/selinux/config
+setenforce 0
+exit 0
+EOF
 }
 
 function download_dependencies() {
@@ -286,7 +319,7 @@ function set_local_repo() {
 }
 
 function check_manifest() {
-    if [[ $1 == $CONTROLLER_ADDRESS ]]; then
+    if [[ $1 == $CONTROLLER_IP ]]; then
         if [[ ! -d $MANIFEST_PATH/$1 ]] || [[ ! -f $MANIFEST_PATH/$1/cluster.manifest ]]; then
             echo "Please check the manifest, then try again."
             exit 1
@@ -304,36 +337,36 @@ function check_manifest() {
 #-------------------------------------------------------------------------------
 
 function setup_remote_controller() {
-    $SSH $USER@$CONTROLLER_ADDRESS "$SUDO rm -rf /etc/manifest/cluster_manifest"
-    $SCP $MANIFEST_PATH/$CONTROLLER_ADDRESS/cluster.manifest $USER@$CONTROLLER_ADDRESS:/tmp
-    $SSH $USER@$CONTROLLER_ADDRESS "$SUDO mv /tmp/cluster.manifest /etc/manifest"
-    $SSH $USER@$CONTROLLER_ADDRESS "$SUDO chown root:vsm /etc/manifest/cluster.manifest; $SUDO chmod 755 /etc/manifest/cluster.manifest"
-    is_cluster_manifest_error=`$SSH $USER@$CONTROLLER_ADDRESS "cluster_manifest|grep error|wc -l"`
+    $SSH $USER@$CONTROLLER_IP "$SUDO rm -rf /etc/manifest/cluster_manifest"
+    $SCP $MANIFEST_PATH/$CONTROLLER_IP/cluster.manifest $USER@$CONTROLLER_IP:/tmp
+    $SSH $USER@$CONTROLLER_IP "$SUDO mv /tmp/cluster.manifest /etc/manifest"
+    $SSH $USER@$CONTROLLER_IP "$SUDO chown root:vsm /etc/manifest/cluster.manifest; $SUDO chmod 755 /etc/manifest/cluster.manifest"
+    is_cluster_manifest_error=`$SSH $USER@$CONTROLLER_IP "cluster_manifest|grep error|wc -l"`
     if [ $is_cluster_manifest_error -gt 0 ]; then
         echo "please check the cluster.manifest, then try again"
         exit 1
     else
         if [[ $OS_KEYSTONE_HOST ]] && [[ $OS_KEYSTONE_ADMIN_TOKEN ]]; then
-            $SSH $USER@$CONTROLLER_ADDRESS "$SUDO vsm-controller --keystone-host $OS_KEYSTONE_HOST --keystone-admin-token $OS_KEYSTONE_ADMIN_TOKEN"
-            $SSH $USER@$CONTROLLER_ADDRESS "if [[ `$SUDO service keystone status|grep running|wc -l` == 1 ]]; then $SUDO service keystone stop; fi"
+            $SSH $USER@$CONTROLLER_IP "$SUDO vsm-controller --keystone-host $OS_KEYSTONE_HOST --keystone-admin-token $OS_KEYSTONE_ADMIN_TOKEN"
+            $SSH $USER@$CONTROLLER_IP "if [[ `$SUDO service keystone status|grep running|wc -l` == 1 ]]; then $SUDO service keystone stop; fi"
         else
-            $SSH $USER@$CONTROLLER_ADDRESS "$SUDO vsm-controller"
+            $SSH $USER@$CONTROLLER_IP "$SUDO vsm-controller"
         fi
     fi
 }
 
 function install_controller() {
-#    _make_me_super $USER $CONTROLLER_ADDRESS
-    check_manifest $CONTROLLER_ADDRESS
+    make_me_super $USER $CONTROLLER_IP
+    check_manifest $CONTROLLER_IP
 
     if [[ $IS_CONTROLLER -eq 0 ]]; then
-        set_remote_repo $CONTROLLER_ADDRESS
-        $SSH $USER@$CONTROLLER_ADDRESS "$SUDO apt-get install -y vsm vsm-deploy vsm-dashboard python-vsmclient diamond"
-        $SSH $USER@$CONTROLLER_ADDRESS "$SUDO preinstall controller"
+        set_remote_repo $CONTROLLER_IP
+        $SSH $USER@$CONTROLLER_IP "$SUDO apt-get install -y vsm vsm-deploy vsm-dashboard python-vsmclient diamond"
+        $SSH $USER@$CONTROLLER_IP "$SUDO preinstall controller"
         setup_remote_controller
-        #$SSH $USER@$CONTROLLER_ADDRESS "ls /var/cache/apt/archives/*.deb"
-        if [ `$SSH $USER@$CONTROLLER_ADDRESS "ls /var/cache/apt/archives/*.deb | wc -l"` -gt 1 ]; then
-            $SCP $USER@$CONTROLLER_ADDRESS:/var/cache/apt/archives/*.deb $REPO_PATH/vsm-dep-repo
+        #$SSH $USER@$CONTROLLER_IP "ls /var/cache/apt/archives/*.deb"
+        if [ `$SSH $USER@$CONTROLLER_IP "ls /var/cache/apt/archives/*.deb | wc -l"` -gt 1 ]; then
+            $SCP $USER@$CONTROLLER_IP:/var/cache/apt/archives/*.deb $REPO_PATH/vsm-dep-repo
         fi
         cd $REPO_PATH
         dpkg-scanpackages vsm-dep-repo | gzip > vsm-dep-repo/Packages.gz
@@ -343,7 +376,7 @@ function install_controller() {
         $SUDO apt-get install -y vsm vsm-deploy vsm-dashboard python-vsmclient diamond
         $SUDO preinstall controller
         $SUDO rm -rf /etc/manifest/cluster.manifest
-        $SUDO cp $MANIFEST_PATH/$CONTROLLER_ADDRESS/cluster.manifest /etc/manifest
+        $SUDO cp $MANIFEST_PATH/$CONTROLLER_IP/cluster.manifest /etc/manifest
         $SUDO chown root:vsm /etc/manifest/cluster.manifest
         $SUDO chmod 755 /etc/manifest/cluster.manifest
         if [ `cluster_manifest|grep error|wc -l` -gt 0 ]; then
@@ -364,27 +397,29 @@ function install_controller() {
         dpkg-scanpackages vsm-dep-repo | gzip > vsm-dep-repo/Packages.gz
         cd $TOPDIR
     fi
-    
-#    generate_token
 }
 
 #-------------------------------------------------------------------------------
 #            agent
 #-------------------------------------------------------------------------------
 
-function kill_diamond() {
+function kill_diamond() { # kill_diamond <node>
     cat <<"EOF" >kill_diamond.sh
 #!/bin/bash
 diamond_pid=`ps -ef|grep diamond|grep -v grep|grep -v bash|grep -v kill_diamond|awk -F " " '{print $2}'`
 for pid in $diamond_pid; do
     sudo -E kill -9 $pid
 done
+exit 0
 EOF
     $SCP kill_diamond.sh $USER@$1:/tmp
-    $SSH $USER@$1 "$SUDO chmod 755 /tmp/kill_diamond.sh;" \
-    "cd /tmp;" \
-    "./kill_diamond.sh;" \
-    "$SUDO rm -rf kill_diamond"
+    $SSH $USER@$1 "bash -x -s" <<EOF
+$SUDO chmod 755 /tmp/kill_diamond.sh
+cd /tmp
+./kill_diamond.sh
+$SUDO rm -rf kill_diamond
+exit 0
+EOF
 }
 
 function install_setup_diamond() {
@@ -392,7 +427,7 @@ function install_setup_diamond() {
     $SSH $USER@$1 "$SUDO apt-get install -y diamond"
     DEPLOYRC_FILE="/etc/vsmdeploy/deployrc"
     if [[ $IS_CONTROLLER -eq 0 ]]; then
-        $SCP $USER@$CONTROLLER_ADDRESS:$DEPLOYRC_FILE /tmp
+        $SCP $USER@$CONTROLLER_IP:$DEPLOYRC_FILE /tmp
         source /tmp/deployrc
     else
         source $DEPLOYRC_FILE
@@ -406,38 +441,40 @@ function install_setup_diamond() {
     HANDLER_PATH="/usr/lib/pymodules/python${PY_VER}/diamond/handler"
     DIAMOND_CONFIG_PATH="/etc/diamond"
 
-    $SSH $USER@$1 "$SUDO cp $DIAMOND_CONFIG_PATH/diamond.conf.example $DIAMOND_CONFIG_PATH/diamond.conf;" \
-    "$SUDO cp $VSMMYSQL_FILE_PATH $HANDLER_PATH;" \
-    "$SUDO sed -i \"s/MySQLHandler/VSMMySQLHandler/g\" $DIAMOND_CONFIG_PATH/diamond.conf;" \
-    "$SUDO sed -i \"s/^handlers = *.*ArchiveHandler$/handlers =  diamond.handler.vsmmysql.VSMMySQLHandler/g\" $DIAMOND_CONFIG_PATH/diamond.conf;" \
-    "$SUDO sed -i \"s/host = graphite/host = 127.0.0.1/g\" $DIAMOND_CONFIG_PATH/diamond.conf;" \
-    "$SUDO sed -i \"s/^hostname*=*.*/hostname    = $CONTROLLER_ADDRESS/g\" $DIAMOND_CONFIG_PATH/diamond.conf;" \
-    "$SUDO sed -i \"s/username    = root/username    = vsm/g\" $DIAMOND_CONFIG_PATH/diamond.conf;" \
-    "$SUDO sed -i \"s/password*=*.*/password    = $MYSQL_VSM_PASSWORD/g\" $DIAMOND_CONFIG_PATH/diamond.conf;" \
-    "$SUDO sed -i \"s/database    = diamond/database    = vsm/g\" $DIAMOND_CONFIG_PATH/diamond.conf;" \
-    "$SUDO sed -i \"/\# INT UNSIGNED NOT NULL/a\# VARCHAR(255) NOT NULL\" $DIAMOND_CONFIG_PATH/diamond.conf;" \
-    "$SUDO sed -i \"/\# INT UNSIGNED NOT NULL/acol_instance = instance\" $DIAMOND_CONFIG_PATH/diamond.conf;" \
-    "$SUDO sed -i \"/\# INT UNSIGNED NOT NULL/a\# VARCHAR(255) NOT NULL\" $DIAMOND_CONFIG_PATH/diamond.conf;" \
-    "$SUDO sed -i \"/\# INT UNSIGNED NOT NULL/acol_hostname    = hostname\" $DIAMOND_CONFIG_PATH/diamond.conf;" \
-    "$SUDO sed -i \"/\# And any other config settings from GraphiteHandler are valid here/i\[\[SignalfxHandler\]\]\" $DIAMOND_CONFIG_PATH/diamond.conf;" \
-    "$SUDO sed -i \"/\# And any other config settings from GraphiteHandler are valid here/iauth_token = abcdefghijklmnopqrstuvwxyz\" $DIAMOND_CONFIG_PATH/diamond.conf;" \
-    "$SUDO sed -i \"s/\# interval = 300/interval = 20/g\" $DIAMOND_CONFIG_PATH/diamond.conf;" \
-    "$SUDO sed -i \"s/enabled = True/#enabled = True/g\" $DIAMOND_CONFIG_PATH/diamond.conf;" \
-    "$SUDO sed -i \"s/\[\[DiskSpaceCollector\]\]/\#\[\[DiskSpaceCollector\]\]/g\" $DIAMOND_CONFIG_PATH/diamond.conf;" \
-    "$SUDO sed -i \"s/\[\[DiskUsageCollector\]\]/\#\[\[DiskUsageCollector\]\]/g\" $DIAMOND_CONFIG_PATH/diamond.conf;" \
-    "$SUDO sed -i \"s/\[\[LoadAverageCollector\]\]/\#\[\[LoadAverageCollector\]\]/g\" $DIAMOND_CONFIG_PATH/diamond.conf;" \
-    "$SUDO sed -i \"s/\[\[MemoryCollector\]\]/\#\[\[MemoryCollector\]\]/g\" $DIAMOND_CONFIG_PATH/diamond.conf;" \
-    "$SUDO sed -i \"s/\[\[VMStatCollector\]\]/\#\[\[VMStatCollector\]\]/g\" $DIAMOND_CONFIG_PATH/diamond.conf;" \
-    "$SUDO sed -i \"/\[\[CPUCollector\]\]/i\[\[CephCollector\]\]\" $DIAMOND_CONFIG_PATH/diamond.conf;" \
-    "$SUDO sed -i \"/\[\[CPUCollector\]\]/ienabled = False\" $DIAMOND_CONFIG_PATH/diamond.conf;" \
-    "$SUDO sed -i \"/\[\[CPUCollector\]\]/i\[\[NetworkCollector\]\]\" $DIAMOND_CONFIG_PATH/diamond.conf;" \
-    "$SUDO sed -i \"/\[\[CPUCollector\]\]/ienabled = False\" $DIAMOND_CONFIG_PATH/diamond.conf;" \
-    "$SUDO sed -i \"/\[\[CPUCollector\]\]/aenabled = False\" $DIAMOND_CONFIG_PATH/diamond.conf;" \
-    "$SUDO service diamond restart"
+    $SSH $USER@$1 "bash -x -s" <<EOF
+$SUDO cp $DIAMOND_CONFIG_PATH/diamond.conf.example $DIAMOND_CONFIG_PATH/diamond.conf
+$SUDO cp $VSMMYSQL_FILE_PATH $HANDLER_PATH
+$SUDO sed -i "s/MySQLHandler/VSMMySQLHandler/g" $DIAMOND_CONFIG_PATH/diamond.conf
+$SUDO sed -i "s/^handlers = *.*ArchiveHandler$/handlers =  diamond.handler.vsmmysql.VSMMySQLHandler/g" $DIAMOND_CONFIG_PATH/diamond.conf
+$SUDO sed -i "s/host = graphite/host = 127.0.0.1/g" $DIAMOND_CONFIG_PATH/diamond.conf
+$SUDO sed -i "s/^hostname*=*.*/hostname    = $CONTROLLER_IP/g" $DIAMOND_CONFIG_PATH/diamond.conf
+$SUDO sed -i "s/username    = root/username    = vsm/g" $DIAMOND_CONFIG_PATH/diamond.conf
+$SUDO sed -i "s/password*=*.*/password    = $MYSQL_VSM_PASSWORD/g" $DIAMOND_CONFIG_PATH/diamond.conf
+$SUDO sed -i "s/database    = diamond/database    = vsm/g" $DIAMOND_CONFIG_PATH/diamond.conf
+$SUDO sed -i "/\# INT UNSIGNED NOT NULL/a\# VARCHAR(255) NOT NULL" $DIAMOND_CONFIG_PATH/diamond.conf
+$SUDO sed -i "/\# INT UNSIGNED NOT NULL/acol_instance = instance" $DIAMOND_CONFIG_PATH/diamond.conf
+$SUDO sed -i "/\# INT UNSIGNED NOT NULL/a\# VARCHAR(255) NOT NULL" $DIAMOND_CONFIG_PATH/diamond.conf
+$SUDO sed -i "/\# INT UNSIGNED NOT NULL/acol_hostname    = hostname" $DIAMOND_CONFIG_PATH/diamond.conf
+$SUDO sed -i "/\# And any other config settings from GraphiteHandler are valid here/i\[\[SignalfxHandler\]\]" $DIAMOND_CONFIG_PATH/diamond.conf
+$SUDO sed -i "/\# And any other config settings from GraphiteHandler are valid here/iauth_token = abcdefghijklmnopqrstuvwxyz" $DIAMOND_CONFIG_PATH/diamond.conf
+$SUDO sed -i "s/\# interval = 300/interval = 20/g" $DIAMOND_CONFIG_PATH/diamond.conf
+$SUDO sed -i "s/enabled = True/#enabled = True/g" $DIAMOND_CONFIG_PATH/diamond.conf
+$SUDO sed -i "s/\[\[DiskSpaceCollector\]\]/\#\[\[DiskSpaceCollector\]\]/g" $DIAMOND_CONFIG_PATH/diamond.conf
+$SUDO sed -i "s/\[\[DiskUsageCollector\]\]/\#\[\[DiskUsageCollector\]\]/g" $DIAMOND_CONFIG_PATH/diamond.conf
+$SUDO sed -i "s/\[\[LoadAverageCollector\]\]/\#\[\[LoadAverageCollector\]\]/g" $DIAMOND_CONFIG_PATH/diamond.conf
+$SUDO sed -i "s/\[\[MemoryCollector\]\]/\#\[\[MemoryCollector\]\]/g" $DIAMOND_CONFIG_PATH/diamond.conf
+$SUDO sed -i "s/\[\[VMStatCollector\]\]/\#\[\[VMStatCollector\]\]/g" $DIAMOND_CONFIG_PATH/diamond.conf
+$SUDO sed -i "/\[\[CPUCollector\]\]/i\[\[CephCollector\]\]" $DIAMOND_CONFIG_PATH/diamond.conf
+$SUDO sed -i "/\[\[CPUCollector\]\]/ienabled = False" $DIAMOND_CONFIG_PATH/diamond.conf
+$SUDO sed -i "/\[\[CPUCollector\]\]/i\[\[NetworkCollector\]\]" $DIAMOND_CONFIG_PATH/diamond.conf
+$SUDO sed -i "/\[\[CPUCollector\]\]/ienabled = False" $DIAMOND_CONFIG_PATH/diamond.conf
+$SUDO sed -i "/\[\[CPUCollector\]\]/aenabled = False" $DIAMOND_CONFIG_PATH/diamond.conf
+$SUDO service diamond restart
+exit 0
+EOF
 }
 
-function setup_remote_agent() {
-#    _make_me_super $USER $1
+function setup_remote_agent() { # setup_remote_agent <node>
     # update /etc/hosts
     #update_hosts $1 
     $SSH $USER@$1 "$SUDO rm -rf /etc/manifest/server.manifest"
@@ -457,13 +494,14 @@ function setup_remote_agent() {
     fi
 }
 
-function cleanup_remote_sources_list()
+function cleanup_remote_sources_list() # cleanup_remote_sources_list <node>
 {
     $SSH $USER@$1 "if [[ -f /etc/apt/sources.list.bak ]]; then $SUDO mv /etc/apt/sources.list.bak /etc/apt/sources.list; fi"
 }
 
-function install_agent() {
+function install_agent() { # install_agent <node>
     echo "=== Install agent [$1] start."
+    make_me_super $USER $1
     generate_token
     $SSH $USER@$1 "if [[ -f /etc/apt/sources.list ]]; then $SUDO mv /etc/apt/sources.list /etc/apt/sources.list.bak; fi"
     check_manifest $1
@@ -479,19 +517,18 @@ function install_agent() {
 }
 
 function generate_token() {
-    TOKEN=`$SSH $USER@$CONTROLLER_ADDRESS "unset http_proxy; agent-token \
-$OS_TENANT_NAME $OS_USERNAME $OS_PASSWORD $OS_KEYSTONE_HOST" |tr -d '\r'`
+    TOKEN=`$SSH $USER@$CONTROLLER_IP "unset http_proxy; agent-token $OS_TENANT_NAME $OS_USERNAME $OS_PASSWORD $OS_KEYSTONE_HOST" |tr -d '\r'`
     echo -n $TOKEN >./.token
 }
 
-function update_hosts() {
+function update_hosts() { # update_hosts <node>
     cp /etc/hosts ./.hosts
     hostname=`$SSH $USER@$1 "hostname" |tr -d '\r'`
     echo "$1    $hostname" >>./.hosts
     cp ./.hosts /etc/hosts
 }
 
-function sync_hosts() {
+function sync_hosts() { # sync_hosts <node>
     $SCP /etc/hosts $USER@$1:~/.hosts
     $SSH $USER@$1 "$SUDO mv ~/.hosts /etc/hosts"
 }
@@ -500,52 +537,52 @@ function sync_hosts() {
 #            start to install
 #-------------------------------------------------------------------------------
 
-if [[ $IS_PREPARE == False ]] && [[ $IS_CONTROLLER_INSTALL == False ]] \
-    && [[ $IS_AGENT_INSTALL == False ]]; then
+exit_code=0
+
+# if --prepare option specified OR no options specified
+if [[ $IS_PREPARE == True ]]; then
     prepare
+fi
+
+# if --controller option specified OR no options specified
+if [[ $IS_CONTROLLER_INSTALL == True ]]; then
     install_controller
-#    generate_token
-    unset tf_list
-    for ip_or_hostname in $AGENT_ADDRESS_LIST; do
+fi
+
+# if --agent option specified OR no options specified
+if [[ $IS_AGENT_INSTALL == True ]]; then
+    pids=""
+    tf_list=""
+    for ip_or_hostname in $AGENT_IPS; do
         tf=$(mktemp)
-        tf_list="${tf_list} ${tf}"
+        tf_list+=" ${tf}"
         echo "=== Starting asynchronous agent install [$ip_or_hostname] ..."
         add_on_exit cleanup_remote_sources_list $ip_or_hostname
-        install_agent $ip_or_hostname >${tf} 2>&1 &
+        ( install_agent $ip_or_hostname >${tf} 2>&1 ) &
+        pids+=" $!"
     done
-    wait
+
+    # wait for agents to complete installing in background
+    for p in $pids; do
+        if ! wait $p; then
+            echo "At least one agent installation failed!"
+            exit_code=1
+        fi
+    done
+
+    # cat each agent log to the screen in startup order
     for tf in ${tf_list}; do cat ${tf}; rm -f ${tf}; done
-else
-    if [[ $IS_PREPARE == True ]]; then
-        prepare
-    fi
-    if [[ $IS_CONTROLLER_INSTALL == True ]]; then
-        install_controller
-    fi
-    if [[ $IS_AGENT_INSTALL == True ]]; then
-#        generate_token
-        AGENT_IP_LIST=${NEW_AGENT_IPS//,/ }
-        unset tf_list
-        for ip_or_hostname in $AGENT_IP_LIST; do
-            tf=$(mktemp)
-            tf_list="${tf_list} ${tf}"
-            echo "=== Starting asynchronous agent install [$ip_or_hostname] ..."
-            add_on_exit cleanup_remote_sources_list $ip_or_hostname
-            install_agent $ip_or_hostname >${tf} 2>&1 &
-        done
-        wait
-        for tf in ${tf_list}; do cat ${tf}; rm -f ${tf}; done
 
-	# sync up /etc/hosts
-	if [[ $IS_CONTROLLER_INSTALL == False ]]; then
-       	    echo "sync /etc/hosts to controller"
-	    #sync_hosts $CONTROLLER_ADDRESS 
-	fi
+    # sync up /etc/hosts to agents
+    for ip_or_hostname in $AGENT_IP_LIST; do
+        echo "sync /etc/hosts to agents"
+        #sync_hosts $ip_or_hostname
+    done
 
-	for ip_or_hostname in $AGENT_IP_LIST; do
-	    echo "sync /etc/hosts to agents"
-	    #sync_hosts $ip_or_hostname
-	done
+    if [[ $IS_CONTROLLER_INSTALL == False ]]; then
+        # sync up /etc/hosts to controller
+        echo "sync /etc/hosts to controller"
+        #sync_hosts $CONTROLLER_IP
     fi
 fi
 
@@ -556,4 +593,6 @@ fi
 echo "Finished."
 
 set +o xtrace
+
+exit $exit_code
 


### PR DESCRIPTION
The install.sh script has been slowly accumulating cruft that cause some of the lesser used command-line arguments to no longer work correctly. This change does several things. First, we cleaned up install.sh to allow all arguments to work correctly (e.g., prepare, controller, agent, etc), and second, we normalized the input arguments so that we could reduce the large if/else clause at the end to a single code path. As a side effect, we also noticed that some of the child scriptlets we were executing on remote hosts could inadvertently return errors, so we added 'exit 0' to these to ensure they returned success to the parent script. Finally, we ensured the agent failures caused the parent script to fail.