### PR TITLE
Move agent install failure message to end of agent output.

### DIFF
--- a/ubuntu14/install.sh
+++ b/ubuntu14/install.sh
@@ -565,7 +565,6 @@ if [[ $IS_AGENT_INSTALL == True ]]; then
     # wait for agents to complete installing in background
     for p in $pids; do
         if ! wait $p; then
-            echo "At least one agent installation failed!"
             exit_code=1
         fi
     done
@@ -584,6 +583,8 @@ if [[ $IS_AGENT_INSTALL == True ]]; then
         echo "sync /etc/hosts to controller"
         #sync_hosts $CONTROLLER_IP
     fi
+
+    test ${exit_code} -ne 0 && echo "ERROR: At least one agent failed to install properly."
 fi
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
Yaguang - this change set moves the "at least one agent installation failed" message to the end of the install.sh output. Previously, we were printing this message and then dumping the contents of every async agent install log to the screen. The final error would get lost in the middle of the log output somewhere.