### PR TITLE
Fix osd restart functionality - osd_status db osd_name field was wron…

### DIFF
--- a/source/vsm/vsm/agent/driver.py
+++ b/source/vsm/vsm/agent/driver.py
@@ -2314,15 +2314,17 @@ class CephDriver(object):
                       run_as_root=True)
         return True
 
-    def ceph_osd_stop(self, context, osd_name, osd_host):
+    def ceph_osd_stop(self, context, osd_name):
         # utils.execute('service',
         #               'ceph',
         #               '-a',
         #               'stop',
         #               osd_name,
         #               run_as_root=True)
-        self._operate_ceph_daemon("stop", "osd", id=osd_name.split(".")[1],
-                                  ssh=True, host=osd_host)
+        osd_id = osd_name.split('.')[-1]
+        self.stop_osd_daemon(context, osd_id)
+        #self._operate_ceph_daemon("stop", "osd", id=osd_name.split(".")[1],
+        #                          ssh=True, host=osd_host)
         #osd_id = osd_name.split('.')[-1]
         #values = {'state': 'Out-Down', 'osd_name': osd_name}
         #ret = self._conductor_rpcapi.\
@@ -2341,7 +2343,7 @@ class CephDriver(object):
         osd=osd[0]
         #stop
         utils.execute('ceph', 'osd', 'set', 'noout', run_as_root=True)
-        self.ceph_osd_stop(context, osd['osd_name'], osd['service']['host'])
+        self.ceph_osd_stop(context, osd['osd_name'])
         #start
         utils.execute('ceph', 'osd', 'unset', 'noout', run_as_root=True)
         self.ceph_osd_start(context, osd['osd_name'])

--- a/source/vsm/vsm/agent/manager.py
+++ b/source/vsm/vsm/agent/manager.py
@@ -2085,7 +2085,7 @@ class AgentManager(manager.Manager):
         osd_state_values = []
 
         for osd in osd_info['osds']:
-            osd_name = osd.get('osd')
+            osd_name = 'osd.'+str(osd.get('osd'))
             cd = osd.get('cd')
             if cd:
                 service_id = db.init_node_get_by_host(context,osd['host'])['service_id']


### PR DESCRIPTION
Hi Yaguang - this change set fixes two issues in the code that were causing osd restart to fail. First, my previously applied import_cluster changes inadvertently set the osd_name field in the osd_status database to just "\<id>", rather than "osd.\<id>" and this was causing an exception at the beginning of osd restart when attempting to parse the \<id> from the string. After fixing this one, restart was till throwing when attempting to stop the osd daemon. This was caused by the restart_osd method calling the wrong internal function to stop the existing daemon prior to starting it again.