### PR TITLE
Fix auto-tune PG functionality

### DIFF
--- a/source/vsm-dashboard/static/dashboard/js/addpool.js
+++ b/source/vsm-dashboard/static/dashboard/js/addpool.js
@@ -32,9 +32,10 @@ function AddPool(){
 			"pool":{
 				"name":$("#txtPoolName").val(),
 				"storageGroupId":$("#selStorageGroup").val(),
-                'storageGroupName': $("#selStorageGroup")[0].options[$("#selStorageGroup")[0].selectedIndex].text,
+				'storageGroupName': $("#selStorageGroup")[0].options[$("#selStorageGroup")[0].selectedIndex].text,
 				"replicatedStorageGroupId":'replica',
-                'auto_growth_pg': $("#txtPGNumber").val(),
+				'pg_num': $("#txtPGNumber").val(),
+				'auto_growth_pg': $("#chkPGNumber")[0].checked ? 1 : 0,
 				'tag': $("#txtTag").val(),
 				'clusterId': "0",
 				'createdBy': "VSM",

--- a/source/vsm/vsm/agent/manager.py
+++ b/source/vsm/vsm/agent/manager.py
@@ -1291,32 +1291,30 @@ class AgentManager(manager.Manager):
                          max_pg_num_per_osd = int(setting['value'])
             auto_growth_pg = pool['auto_growth_pg']
             if auto_growth_pg:
-                max_pg_num_finally = auto_growth_pg
-            else:
                 size = pool['size']
                 if pool['size'] == 0:
                     pool_default_size = db.vsm_settings_get_by_name(context,'osd_pool_default_size')
                     size = int(pool_default_size.value)
                 max_pg_num_finally = max_pg_num_per_osd * osd_num_per_group//size
-            if max_pg_num_finally > pool['pg_num']:
-                pg_num = max_pg_num_finally#self._compute_pg_num(context, osd_num_per_group, pool['size'])
-                LOG.info("pool['crush_ruleset'] id %s has %s osds" % (pool['crush_ruleset'], osd_num_per_group))
-                if osd_num_per_group > 64:
-                    osd_num_per_group = 64
-                    LOG.info("osd_num_per_group > 64, use osd_num_per_group=64")
-                step_max_pg_num = osd_num_per_group * 32
-                max_pg_num = step_max_pg_num + pool['pg_num']
-                if pg_num > max_pg_num_finally:
-                    pgp_num = pg_num = max_pg_num_finally
-                    self.set_pool_pg_pgp_num(context, pool['name'], pg_num, pgp_num)
-                elif pg_num > max_pg_num:
-                    pgp_num = pg_num = max_pg_num
-                    self.set_pool_pg_pgp_num(context, pool['name'], pg_num, pgp_num)
-                elif pg_num > pool['pg_num']:
-                    pgp_num = pg_num
-                    self.set_pool_pg_pgp_num(context, pool['name'], pg_num, pgp_num)
-                else:
-                    continue
+                if max_pg_num_finally > pool['pg_num']:
+                    pg_num = max_pg_num_finally#self._compute_pg_num(context, osd_num_per_group, pool['size'])
+                    LOG.info("pool['crush_ruleset'] id %s has %s osds" % (pool['crush_ruleset'], osd_num_per_group))
+                    if osd_num_per_group > 64:
+                        osd_num_per_group = 64
+                        LOG.info("osd_num_per_group > 64, use osd_num_per_group=64")
+                    step_max_pg_num = osd_num_per_group * 32
+                    max_pg_num = step_max_pg_num + pool['pg_num']
+                    if pg_num > max_pg_num_finally:
+                        pgp_num = pg_num = max_pg_num_finally
+                        self.set_pool_pg_pgp_num(context, pool['name'], pg_num, pgp_num)
+                    elif pg_num > max_pg_num:
+                        pgp_num = pg_num = max_pg_num
+                        self.set_pool_pg_pgp_num(context, pool['name'], pg_num, pgp_num)
+                    elif pg_num > pool['pg_num']:
+                        pgp_num = pg_num
+                        self.set_pool_pg_pgp_num(context, pool['name'], pg_num, pgp_num)
+                    else:
+                        continue
 
         ceph_pools = self.ceph_driver.get_pool_status()
         for pool in ceph_pools:

--- a/source/vsm/vsm/api/v1/storage_pool.py
+++ b/source/vsm/vsm/api/v1/storage_pool.py
@@ -359,10 +359,7 @@ class StoragePoolController(wsgi.Controller):
             #pg_num = self._compute_pg_num(context, osd_num, size)
 
             #vsm_id = str(uuid.uuid1()).split('-')[0]
-            pg_num = 64
-            auto_growth_pg = pool_dict.get("auto_growth_pg",0)
-            if  auto_growth_pg and int(auto_growth_pg) < pg_num and int(auto_growth_pg) > 0:
-                pg_num = int(auto_growth_pg)
+            pg_num = pool_dict.get('pg_num', 64)
             #self._compute_pg_num(context, osd_num, size)
             body_info = {'name': name, #+ "-vsm" + vsm_id,
                         'cluster_id':cluster_id,


### PR DESCRIPTION
The auto-tune PG function for replicated pools was not working correctly,
any replicated pool created by VSM would actually never rebalance based on
cluster config, while pools externally created by Ceph would be rebalanced
without user input or consent.