### PR TITLE
Fix minor typos in EC profile management

### DIFF
--- a/source/vsm-dashboard/vsm_dashboard/dashboards/vsm/dashboard.py
+++ b/source/vsm-dashboard/vsm_dashboard/dashboards/vsm/dashboard.py
@@ -26,13 +26,13 @@ class Dashboard(horizon.PanelGroup):
 class ClusterMgmt(horizon.PanelGroup):
     slug = "clustermgmt"
     name = _("Cluster Management")
-    panels = ('clustermgmt', 'cluster-import', 'cephupgrade', 'poolsmanagement','crushmap','zonemgmt')
+    panels = ('clustermgmt', 'cluster-import', 'cephupgrade', 'poolsmanagement','ecprofiles-management','crushmap','zonemgmt')
 
 class ClusterMonitor(horizon.PanelGroup):
     slug = "clustermonitor"
     name = _("Cluster Monitoring")
     panels = ('storage-group-status', 'pool-status', 'osd-status', 'monitor-status', \
-              'mds-status', 'pg-status', 'rbd-status','ecprofiles-management')
+              'mds-status', 'pg-status', 'rbd-status')
 
 class ServerMgmt(horizon.PanelGroup):
     slug = "servermgmt"

--- a/source/vsm-dashboard/vsm_dashboard/dashboards/vsm/ecprofiles-management/panel.py
+++ b/source/vsm-dashboard/vsm_dashboard/dashboards/vsm/ecprofiles-management/panel.py
@@ -20,7 +20,7 @@ import horizon
 from vsm_dashboard.dashboards.vsm import dashboard
 
 class ECProFilesManagement(horizon.Panel):
-    name = _("Manage EC Pro files")
+    name = _("Manage EC Profiles")
     slug = 'ecprofiles-management'
 
 dashboard.VizDash.register(ECProFilesManagement)

--- a/source/vsm-dashboard/vsm_dashboard/dashboards/vsm/ecprofiles-management/tables.py
+++ b/source/vsm-dashboard/vsm_dashboard/dashboards/vsm/ecprofiles-management/tables.py
@@ -48,7 +48,7 @@ class ECProfilesTable(tables.DataTable):
     k_v_dict = tables.Column("plugin_kv_pair", verbose_name=_("Key Values Pairs"))
     class Meta:
         name = "ec_profiles"
-        verbose_name = _("EC Pro Files List")
+        verbose_name = _("EC Profiles List")
         table_actions = (AddECProfileAction,RemoveECProfilesAction)
 
     def get_object_id(self, datum):

--- a/source/vsm-dashboard/vsm_dashboard/dashboards/vsm/ecprofiles-management/templates/ecprofiles-management/add_ec_profile.html
+++ b/source/vsm-dashboard/vsm_dashboard/dashboards/vsm/ecprofiles-management/templates/ecprofiles-management/add_ec_profile.html
@@ -17,10 +17,10 @@
 
 {% extends 'base.html' %}
 {% load i18n %}
-{% block title %}Create EC Pro files{% endblock %}
+{% block title %}Create EC Profiles{% endblock %}
 
 {% block page_header %}
-  {% include "horizon/common/_page_header.html" with title=_("Create EC Pro file") %}
+  {% include "horizon/common/_page_header.html" with title=_("Create EC Profile") %}
   <link href="{{ STATIC_URL }}dashboard/css/poolmgmt.css" rel="stylesheet">
 
 {% endblock page_header %}

--- a/source/vsm-dashboard/vsm_dashboard/dashboards/vsm/ecprofiles-management/templates/ecprofiles-management/index.html
+++ b/source/vsm-dashboard/vsm_dashboard/dashboards/vsm/ecprofiles-management/templates/ecprofiles-management/index.html
@@ -16,10 +16,10 @@
 
 {% extends 'base.html' %}
 {% load i18n %}
-{% block title %}{% trans "Manage EC Pro files" %}{% endblock %}
+{% block title %}{% trans "Manage EC Profiles" %}{% endblock %}
 
 {% block page_header %}
-    {% include "horizon/common/_page_header.html" with title=_("Manage EC Pro files") %}
+    {% include "horizon/common/_page_header.html" with title=_("Manage EC Profiles") %}
     <link href="{{ STATIC_URL }}dashboard/css/devicemgmt.css" rel="stylesheet">
 {% endblock page_header %}
 


### PR DESCRIPTION
Fix typos of "Pro files" in EC Profile management page and move it under
'cluster management' instead of 'cluster monitoring'