### PR TITLE
Display friendly name on 'Storage Group Status' page

### DIFF
--- a/source/vsm-dashboard/vsm_dashboard/dashboards/vsm/storage-group-status/tables.py
+++ b/source/vsm-dashboard/vsm_dashboard/dashboards/vsm/storage-group-status/tables.py
@@ -85,6 +85,7 @@ class ListStorageGroupStatusTable(tables.DataTable):
 
     #server_id = tables.Column("id", verbose_name=_("ID"))
     storage_group = tables.Column("name", verbose_name=_("Storage Group"))
+    friendly_name = tables.Column("friendly_name", verbose_name=_("Friendly Name"))
     #attached_osds = tables.Column("attached_osds", verbose_name=_("Attached Osds"))
     attached_pools = tables.Column("attached_pools", verbose_name=_("Attached Pools"))
     capacity_total = tables.Column("capacity_total", verbose_name=_("Capacity Total (GB)"))

--- a/source/vsm-dashboard/vsm_dashboard/dashboards/vsm/storage-group-status/views.py
+++ b/source/vsm-dashboard/vsm_dashboard/dashboards/vsm/storage-group-status/views.py
@@ -60,6 +60,7 @@ class IndexView(ModalChartMixin, tables.DataTableView):
         for _sg in _sgs:
             sg = {"id": _sg.id,
                         "name": _sg.name,
+                        "friendly_name", _sg.friendly_name
                         "attached_pools": _sg.attached_pools,
                         "capacity_total": 0 if not _sg.capacity_total else round(_sg.capacity_total * 1.0 / 1024 / 1024, 1),
                         "capacity_used": 0 if not _sg.capacity_used else round(_sg.capacity_used * 1.0 / 1024 / 1024, 1),


### PR DESCRIPTION
Storage group 'Friendly name' isn't shown anywhere on the 'Storage Group Status' page - should be added