### PR TITLE
Typo in previous pull request

### DIFF
--- a/source/vsm-dashboard/vsm_dashboard/dashboards/vsm/storage-group-status/views.py
+++ b/source/vsm-dashboard/vsm_dashboard/dashboards/vsm/storage-group-status/views.py
@@ -60,7 +60,7 @@ class IndexView(ModalChartMixin, tables.DataTableView):
         for _sg in _sgs:
             sg = {"id": _sg.id,
                         "name": _sg.name,
-                        "friendly_name", _sg.friendly_name
+                        "friendly_name", _sg.friendly_name,
                         "attached_pools": _sg.attached_pools,
                         "capacity_total": 0 if not _sg.capacity_total else round(_sg.capacity_total * 1.0 / 1024 / 1024, 1),
                         "capacity_used": 0 if not _sg.capacity_used else round(_sg.capacity_used * 1.0 / 1024 / 1024, 1),


### PR DESCRIPTION
Missed a ',' when I copied the patch contents from my test system which caused the dashboard to fail to load