### PR TITLE
Add non-interactive flag to apt-get in preinstall.

### DIFF
--- a/ubuntu14/vsm-deploy/preinstall
+++ b/ubuntu14/vsm-deploy/preinstall
@@ -10,7 +10,7 @@ function preinstall_controller() {
 }
 
 function preinstall_agent() {
-    apt-get install -y ceph ceph-mds librbd1 rbd-fuse radosgw \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y ceph ceph-mds librbd1 rbd-fuse radosgw \
     ntp openssh-server python-keystoneclient expect smartmontools
 }
 


### PR DESCRIPTION
Setting this DEBIAN_FRONTEND variable allows vsm to install quietly, even when packages like mariadb try to interactively query the user for instructions.