### PR TITLE
Reduce interval on OSD status check from 10 min to 1 min.

### DIFF
--- a/source/vsm/vsm/flags.py
+++ b/source/vsm/vsm/flags.py
@@ -488,7 +488,7 @@ vsm_settings_opts = [
                default=600,
                help='update ceph version info(secs)'),
     cfg.IntOpt('ceph_osd_dump',
-               default=600,
+               default=60,
                help='ceph osd dump (secs)'),
     cfg.IntOpt('ceph_pg_dump_osds',
                default=600,


### PR DESCRIPTION
10 minutes seemed like much too long to wait for OSD changes - reducing to 1 minute doesn't overtax the system.