### PR TITLE
Adjust column widths in dashboard capacity display so values don't wrap.

### DIFF
--- a/source/vsm-dashboard/static/dashboard/css/dashboard.css
+++ b/source/vsm-dashboard/static/dashboard/css/dashboard.css
@@ -272,8 +272,11 @@
     margin-left: 10px;
 }
 
-#tCapacityInfo tr td{
-    width: 70px;
+#tCapacityLabel{
+    width: 50px;
 }
 
+#tCapacityValue{
+    width: 100px;
+}
 

--- a/source/vsm-dashboard/vsm_dashboard/dashboards/vsm/overview/templates/overview/index.html
+++ b/source/vsm-dashboard/vsm_dashboard/dashboards/vsm/overview/templates/overview/index.html
@@ -52,12 +52,12 @@
                         <div id="divCapacityInfo">
                             <table id="tCapacityInfo">
                                 <tr>
-                                    <td><span id="lblCapacityUsedMark">{% trans "Used" %}:</span></td>
-                                    <td><span id="lblCapacityUsed">--</span></td>
+                                    <td id="tCapacityLabel"><span id="lblCapacityUsedMark">{% trans "Used" %}:</span></td>
+                                    <td id="tCapacityValue"><span id="lblCapacityUsed">--</span></td>
                                 </tr>
                                 <tr>
-                                    <td><span id="lblCapacityTotalMark">{% trans "Total" %}:</span></td>
-                                    <td><span id="lblCapacityTotal" >--</span></td>
+                                    <td id="tCapacityLabel"><span id="lblCapacityTotalMark">{% trans "Total" %}:</span></td>
+                                    <td id="tCapacityValue"><span id="lblCapacityTotal" >--</span></td>
                                 </tr>
                             </table>
                         </div>


### PR DESCRIPTION
Hi Yaguang. This change set adjusts the column widths for the label and value on the dashboard cluster capacity display so the values don't wrap if they're just a little too long.