### PR TITLE
Change user-mgmt more button color so it's visible.

### DIFF
--- a/ubuntu14/vsm-dashboard/static/dashboard/css/ubuntu.css
+++ b/ubuntu14/vsm-dashboard/static/dashboard/css/ubuntu.css
@@ -10844,7 +10844,7 @@ body {
       border-radius: 3px;
       /*background: #dd4814;*/
       border: none;
-      color: #fff;
+      /*color: #fff;*/
       text-decoration: none;
       display: inline-block;
       margin: 0;


### PR DESCRIPTION
The "more v" dropdown menu is nearly invisible on the user management screen (for non-admin users created after installation) because the text is colored white and the background is light grey. By removing the color, the default blue takes effect. Must simpler to read.