### PR TITLE
Fix the formatting of the dashboard PG widget

### DIFF
--- a/source/vsm-dashboard/static/dashboard/js/dashboard.js
+++ b/source/vsm-dashboard/static/dashboard/js/dashboard.js
@@ -982,26 +982,53 @@ function GetBandwidthOption(){
 //NAC: not active+clean
 function GetPieOption(AC,NAC){
     var option = {
-	    tooltip : {
-		trigger: 'item',
-		formatter: "{b} : {c} ({d}%)"
-	    },
+            tooltip : {
+                trigger: 'item',
+                formatter: "{b} : {c} ({d}%)",
+                position: function(p) {
+                    return [0, p[1]];
+                }
+            },
+            legend: {
+                x: 'left',
+                y: 'top',
+                orient: 'vertical',
+                textStyle: {
+                    color: 'auto',
+                    fontSize: 14
+                },
+                data: [
+                    {name: 'Active+Clean'},
+                    {name: 'Not Active+Clean'},
+                ]
+            },
             series : [
-		{
-		    name:'PG Summary',
-		    type:'pie',
-		    radius : '60%',
-		    center: ['50%', '50%'],
-		    data:[
-		        {value:AC, name:'Active+Clean'},
-		        {value:NAC, name:'Not Active+Clean'},
-		    ]
-		}
-	    ],
+                {
+                    name:'PG Summary',
+                    type:'pie',
+                    radius : '75%',
+                    center: ['50%', '65%'],
+                    itemStyle: {
+                        normal: {
+                            label: {
+                                show: false
+                            },
+                            labelLine: {
+                                show: false
+                            }
+                        }
+                    },
+                    data: [
+                        {value:AC, name: 'Active+Clean'},
+                        {value:NAC, name: 'Not Active+Clean'},
+                    ],
+                }
+            ],
             color:["green","orange"]
- 	};
-                    
-	return option;
+        };
+
+
+    return option;
 }
 
 function InitAxis_X(){


### PR DESCRIPTION
Labels and tooltips on the dashboard PG widget always display outside
the widget borders.  Add a legend, remove the labels, anchor the tooltip
to the border of the widget, and increase the size since the labels no
longer display

**Before:**
![pg widget before](https://cloud.githubusercontent.com/assets/12177893/15129500/38072c10-15ff-11e6-9eba-1de3712ace75.png)
**After:**
![pg widget after](https://cloud.githubusercontent.com/assets/12177893/15129499/37f4b044-15ff-11e6-8063-97e4d77f605f.png)