### PR TITLE
Fix bug: can't show CPU usage data in dashboard

### DIFF
--- a/source/vsm/vsm/agent/driver.py
+++ b/source/vsm/vsm/agent/driver.py
@@ -1720,8 +1720,8 @@ class CephDriver(object):
         self._operate_ceph_daemon("start", "osd", id=num)
         return True
 
-    def stop_mon_daemon(self, context, num):
-        file_path = '/var/run/ceph/mon.%s.pid' % num
+    def stop_mon_daemon(self, context, name):
+        file_path = '/var/run/ceph/mon.%s.pid' % name
         # no using os.path.exists(), because if the file is owned by ceph
         # user, the result will return false
         try:
@@ -1732,23 +1732,23 @@ class CephDriver(object):
         if out:
             self._kill_by_pid_file(file_path)
         else:
-            LOG.info("Not found pid file for mon.%s" % num)
+            LOG.info("Not found pid file for mon.%s" % name)
             try:
-                LOG.info("Try to stop mon %s daemon by ceph or ceph-mon command" % num)
-                self._operate_ceph_daemon("stop", "mon", id=num)
+                LOG.info("Try to stop mon %s daemon by ceph or ceph-mon command" % name)
+                self._operate_ceph_daemon("stop", "mon", id=name)
             except:
-                LOG.warn("Mon %s has NOT been stopped" % num)
+                LOG.warn("Mon %s has NOT been stopped" % name)
         return True
 
-    def start_mon_daemon(self, context, num):
+    def start_mon_daemon(self, context, name):
         try:
-            self.stop_mon_daemon(context, num)
+            self.stop_mon_daemon(context, name)
         except:
             pass
         # mon_name = 'mon.%s' % num
         # utils.execute('service', 'ceph', 'start', mon_name, run_as_root=True)
         try:
-            self._operate_ceph_daemon("start", "mon", id=num)
+            self._operate_ceph_daemon("start", "mon", id=name)
         except:
             LOG.warn("Monitor has NOT been started!")
         return True
@@ -1805,7 +1805,7 @@ class CephDriver(object):
         mons = monmap['mons']
         for mon in mons:
             if mon['name'] == FLAGS.host:
-                mon_id = mon['rank']
+                mon_id = mon['name']
 
         # Try to start monitor service.
         if mon_id:
@@ -1823,7 +1823,7 @@ class CephDriver(object):
         mons = monmap['mons']
         for mon in mons:
             if mon['name'] == FLAGS.host:
-                mon_id = mon['rank']
+                mon_id = mon['name']
 
         # Try to stop monitor service.
         if mon_id:

--- a/source/vsm/vsm/db/sqlalchemy/api.py
+++ b/source/vsm/vsm/db/sqlalchemy/api.py
@@ -4139,7 +4139,10 @@ def ec_profile_get_by_name(context, name, session=None):
 
 def get_max_timestamp_by_metrics_name(context, metrics_name, session=None):
     session = get_session()
-    sql_str = "select timestamp from metrics where metric='%s' order by timestamp desc limit 1;"%metrics_name
+    if "cpu" in metrics_name:
+        sql_str = "select timestamp from metrics where metric like 'cpu%' order by timestamp desc limit 1;"
+    else:
+        sql_str = "select timestamp from metrics where metric='%s' order by timestamp desc limit 1;"%metrics_name
     sql_ret = session.execute(sql_str).fetchall()
     return sql_ret[0][0]
 
@@ -4253,7 +4256,7 @@ def cpu_data_get_usage(context, search_opts, session=None):#for cpu_usage
         return []
     # Get timestamps for metric interval
     metrics_name = search_opts['metrics_name']
-    timestamp_start, timestamp_end = get_metric_timestamp_range(context, search_opts, diamond_collect_interval)
+    timestamp_start, timestamp_end = get_metric_timestamp_range(context, search_opts, diamond_collect_interval, metrics_name=metrics_name)
     if timestamp_start > timestamp_end:
         return []
     ret_list = []


### PR DESCRIPTION
Since in cpu_data_get_usage(), that the parameter 'metrics_name' wasn't
pass into get_metric_timestamp_range() resulted in invalid timestamp_end
value. And in get_max_timestamp_by_metrics_name(), the metrics_name
'cpu_usage' didn't match any of metric in the table 'metrics', so it
should use other sql statement to get cpu_usage max timestamp.
    
Signed-off-by: 李海静 <lihaijing@fiberhome.com>