### PR TITLE
Scaling on the IOPS widget goes off the edge once values go above 10000.

### DIFF
--- a/source/vsm-dashboard/static/dashboard/js/dashboard.js
+++ b/source/vsm-dashboard/static/dashboard/js/dashboard.js
@@ -731,7 +731,16 @@ function GenerateLineOption(){
                 //max:15,
                 axisLabel:{
                     show:true,
-                    interval:'auto'
+                    interval: 'auto',
+                    formatter: function(value) {
+                        var units = ["", "K", "M", "G", "T"]
+                        var intval = +value
+                        var idx = 0;
+                        while(intval >= 1000 && ++idx < units.length){
+                            intval /= 1000;
+                        }
+                        return intval + units[idx];
+                    }
                 },
                 name : '',
                 boundaryGap: [0.5, 0.5]


### PR DESCRIPTION
Change the Y-axis to display a truncated version of the value (i.e. 400K, 1M, etc)