### PR TITLE
fix the issue of removing monitors on ceph jewel

### DIFF
--- a/source/vsm/vsm/agent/driver.py
+++ b/source/vsm/vsm/agent/driver.py
@@ -1483,11 +1483,17 @@ class CephDriver(object):
 
         # step 2
         LOG.info('>> removing ceph mon step 2')
-        utils.execute("ceph",
-                      "mon",
-                      "remove",
-                      mon_id,
-                      run_as_root=True)
+        # fix the issue of ceph jewel version when remove the monitor,
+        # it will throw the Error EINVAL, but the monitor remove successfully.
+        try:
+            utils.execute("ceph",
+                          "mon",
+                          "remove",
+                          mon_id,
+                          run_as_root=True)
+        except:
+            LOG.warn("Ceph throws out an error, but monitor has been remove successfully")
+            pass
         if not is_stop:
             config.remove_mon(mon_id)
         # step 3


### PR DESCRIPTION
when removing monitors on ceph jewel version, It will throw out the error messages "Error EINVAL: removing mon.3 at 10.168.10.142:6789/0, there will be 3 monitors". But the monitors will be removed successfully.