### PR TITLE
Fix 'Cluster Status' widget when cluster is in error state

### DIFF
--- a/source/vsm-dashboard/static/dashboard/js/dashboard.js
+++ b/source/vsm-dashboard/static/dashboard/js/dashboard.js
@@ -186,7 +186,7 @@ function loadClusterStatus(){
                     statusClass = "cluster-tip cluster-tip-warning";
                     noteClass = "alert alert-warning";
                     break;
-                case "HEALTH_ERROR": //error
+                case "HEALTH_ERR": //error
                     statusTip = "error";
                     statusClass = "cluster-tip cluster-tip-error";
                     noteClass = "alert alert-danger";

--- a/source/vsm-dashboard/vsm_dashboard/dashboards/vsm/overview/summarys.py
+++ b/source/vsm-dashboard/vsm_dashboard/dashboards/vsm/overview/summarys.py
@@ -240,7 +240,7 @@ class ClusterSummary(SummaryRenderer):
                 self.css_id = "health_ok"
             elif status.find('war') != -1:
                 self.css_id = "health_warning"
-            elif status.find('error') != -1:
+            elif status.find('err') != -1:
                 self.css_id = "health_error"
 
             msg = self.font % (self.css_id, data["Status"])

--- a/source/vsm-dashboard/vsm_dashboard/dashboards/vsm/overview/views.py
+++ b/source/vsm-dashboard/vsm_dashboard/dashboards/vsm/overview/views.py
@@ -148,7 +148,7 @@ def get_version():
 def get_cluster():
     cluster_summary = vsmapi.cluster_summary(None)
     cluster_name = vsmapi.get_cluster_list(None)[1]['clusters'][0]['name']
-    #HEALTH_OK HEALTH_WARN  HEALTH_ERROR
+    #HEALTH_OK HEALTH_WARN  HEALTH_ERR
     cluster_status = cluster_summary.health_list[0]
     cluster_note = []
     for note in cluster_summary.health_list[1:]:


### PR DESCRIPTION
'ceph health' for cluster error state is "HEALTH_ERR", not "HEALTH_ERROR", so GUI failed to display
error state properly