### PR TITLE
Change config parser to use python ConfigParser.

### DIFF
--- a/source/vsm/vsm/agent/cephconfigparser.py
+++ b/source/vsm/vsm/agent/cephconfigparser.py
@@ -27,6 +27,8 @@ Tools for ceph config.
 
 import os
 import uuid
+import ConfigParser
+from cStringIO import StringIO
 from vsm import utils
 from vsm import context as vsm_context
 from vsm import manager
@@ -34,169 +36,9 @@ from vsm import flags
 from vsm import db
 from vsm.agent import rpcapi as agent_rpc
 from vsm.openstack.common import log as logging
-from vsm.openstack.common.gettextutils import _
 
 LOG = logging.getLogger(__name__)
 FLAGS = flags.FLAGS
-
-class Section(object):
-    def __init__(self, name=None, options=None):
-        self.sec_name = name
-        self.options = options or {}
-
-    def name(self):
-        return self.sec_name
-
-    def values(self):
-        return self.options
-
-    def set(self, key, value):
-        self.options[key] = value
-
-    def get(self, key):
-        return self.options[key]
-
-    def as_dict(self):
-        return {self.sec_name: self.options}
-
-    def as_str(self):
-        label = "[%s]\n" % self.sec_name
-        content = ""
-        for (key, val) in self.options.items():
-            content = content + ("%s = %s\n" % (key, val))
-
-        return label + content
-
-class Parser(object):
-    def __init__(self):
-        self._sections = {}
-
-    def init(self, contents):
-        self._sections = {}
-
-        sec_name = None
-        options = {}
-        for line in contents:
-            line = line.strip()
-            if line.startswith('#') or len(line) <= 1:
-                continue
-
-            if line.find('#') != -1:
-                vs = line.split('#')
-                line = vs[0]
-
-            if line.find('[') != -1 and line.find(']') != -1:
-                line = line.replace('[', ' ')
-                line = line.replace(']', ' ').strip()
-
-                if sec_name:
-                    self._sections[sec_name] = options
-
-                sec_name = line
-                options = {}
-            elif line.find('=') != -1:
-                key = line[0:line.find('=')].strip()
-                val = line[line.find('=')+1:].strip()
-                options[key] = val
-
-        self._sections[sec_name] = options
-
-    def read(self, file_path):
-        with open(file_path, 'r') as f:
-            content = f.readlines()
-            self.init(content)
-
-    def write(self, file_path, rgw=False):
-        content = self.as_str(rgw)
-        with open(FLAGS.ceph_conf, 'w') as f:
-            f.write(content)
-            f.write('\n')
-
-    def as_dict(self):
-        return self._sections
-
-    def as_str(self, rgw=False):
-        lines = ""
-        d = self._sections.copy()
-        def _sec_as_str(sec_name):
-            return Section(sec_name, d[sec_name]).as_str() + '\n'
-
-        def _secs_as_str(sec_type):
-            strs = ''
-            if sec_type != "client":
-                strs = _sec_as_str(sec_type)
-                d.pop(sec_type)
-            drop_list = []
-            for sec in d:
-                if sec.find(sec_type+'.') != -1:
-                    drop_list.append(sec)
-
-            for sec in sorted(drop_list):
-                strs = strs + _sec_as_str(sec)
-
-            for sec in drop_list:
-                if sec.find(sec_type+'.') != -1:
-                    d.pop(sec)
-
-            return strs
-
-        if self.has_section('global'):
-            lines = lines + _secs_as_str('global')
-
-        if self.has_section('mon'):
-            lines = lines + _secs_as_str('mon')
-
-        if self.has_section('mds'):
-            lines = lines + _secs_as_str('mds')
-
-        if self.has_section('osd'):
-            lines = lines + _secs_as_str('osd')
-
-        if rgw:
-            lines = lines + _secs_as_str("client")
-
-        lines = lines.strip()
-
-        return lines
-
-    def has_section(self, sec_name):
-        sec_name = sec_name.strip()
-        if self._sections.get(sec_name):
-            return True
-        return False
-
-    def add_section(self, sec_name):
-        sec_name = sec_name.strip()
-        if self.has_section(sec_name):
-            return
-
-        self._sections[sec_name] = {}
-
-    def remove_section(self, sec_name):
-        sec_name = sec_name.strip()
-        if not self.has_section(sec_name):
-            return
-
-        self._sections.pop(sec_name)
-
-    def get(self, sec_name, key, default_val=None):
-        if not self.has_section(sec_name):
-            return None
-
-        sec = self._sections[sec_name]
-        if sec.get(key, None):
-            return sec.get(key, default_val)
-
-        return sec.get(key.replace('_', ' '), default_val)
-
-    def set(self, sec_name, key, val):
-        sec_name = sec_name.strip()
-        key = key.strip()
-        val = val.strip()
-        self._sections[sec_name][key] = val
-
-    def sections(self):
-        return self._sections
 
 class CephConfigParser(manager.Manager):
     cluster_id = None
@@ -213,28 +55,13 @@ class CephConfigParser(manager.Manager):
         self.cluster_id = cid
         return self.cluster_id
 
-    def _load_ceph_conf_from_db(self):
-        if not self.cluster_id:
-            if not self._get_cluster_id():
-                LOG.debug('Can not get cluster_id')
-                return
+    def _update_etc_fstab(self):
 
-        ceph_conf = db.cluster_get_ceph_conf(self.context,
-                                             self.cluster_id)
+        # NOTE: This routine fails as it relies on [TYP.X] sections, which are no longer required or configured.
 
-        if not ceph_conf:
-            return
-
-        utils.write_file_as_root(FLAGS.ceph_conf, ceph_conf, 'w')
-
-        # We try to update fstab here.
-        utils.execute('sed',
-                      '-i',
-                      '/forvsmosd/d',
-                      '/etc/fstab',
-                      run_as_root=True)
-
-        parser = Parser()
+        utils.execute('sed', '-i', '/forvsmosd/d', '/etc/fstab', run_as_root=True)
+        parser = ConfigParser.ConfigParser()
+        parser.optionxform = self._parser.optionxform
         parser.read(FLAGS.ceph_conf)
         fs_type = parser.get('osd', 'osd mkfs type', 'xfs')
         cluster = db.cluster_get_all(self.context)[0]
@@ -256,24 +83,51 @@ class CephConfigParser(manager.Manager):
                     line = line + ' ' + '## forvsmosd'
                     utils.write_file_as_root('/etc/fstab', line)
 
+    def _load_ceph_conf_from_db(self):
+        if not self.cluster_id:
+            if not self._get_cluster_id():
+                LOG.debug('Can not get cluster_id; unable to load ceph conf from db')
+                return
+
+        ceph_conf = db.cluster_get_ceph_conf(self.context, self.cluster_id)
+        if not ceph_conf:
+            return
+
+        utils.write_file_as_root(FLAGS.ceph_conf, ceph_conf, 'w')
+
+        self._update_etc_fstab()
+
+    def _load_ceph_conf_from_dict(self, dict_cfg):
+        """
+        Load ceph configuration parameters from a section:options dictionary of dictionaries.
+        :param dict_cfg: {section: {option:value, option:value}, section...}
+        :return: none
+        """
+        try:
+            for section,options in dict_cfg.iteritems():
+                self._parser.add_section(section)
+                for option,value in options.iteritems():
+                    self._parser.set(section, option, value)
+        except:
+            raise TypeError("dict_cfg must be a dict of dicts - {section:{option:value,...},...}")
+
     def __init__(self, fp=None, *args, **kwargs):
         super(CephConfigParser, self).__init__(*args, **kwargs)
-        self._parser = Parser()
-        self._load_ceph_conf_from_db()
+        self._parser = ConfigParser.ConfigParser()
+        self._parser.optionxform = lambda optname: optname.lower().replace(' ', '_')
 
-        try:
-            if not fp is None:
-                if isinstance(fp, str) or isinstance(fp, unicode):
-                    if os.path.exists(fp) and os.path.isfile(fp):
-                        self._parser.read(fp)
-                elif isinstance(fp, dict):
-                    for k, v  in fp.iteritems():
-                        self._parser.add_section(k)
-                        for key, val in v.iteritems():
-                            self._parser.set(k, key, val)
-        except:
-            LOG.error(_('Failed to load ceph configuration'))
-            raise
+        # NOTE: fp can be a file name in str or unicode format OR a dictionary of dictionaries
+
+        if fp is None:
+            self._load_ceph_conf_from_db()
+        elif isinstance(fp, str) or isinstance(fp, unicode):
+            self._parser.read(fp)
+        elif isinstance(fp, dict):
+            self._load_ceph_conf_from_dict(fp)
+        else:
+            raise TypeError("'fp' must be a string or dictionary")
+
+    # NOTE: The following methods are obsolete since ceph.conf files no longer contain [mon.X], [mds.X], and [ods.X] sections
 
     def __get_type_number(self, sec_type):
         cnt = 0
@@ -291,66 +145,74 @@ class CephConfigParser(manager.Manager):
     def get_osd_num(self):
         return self.__get_type_number('osd.')
 
+    # NOTE: End of obsolete code section (see previous note).
+
     def as_sections(self):
-        return self._parser._sections
+
+        # NOTE: There is no equivalent to this routine in python's ConfigParser; calling code should be reworked
+        # to call another routine that's more efficient relative to ConfigParser, and a new method should be added
+        # to this code that provides access to these other ConfigParser routines.
+
+        sections = {}
+        for section in self._parser.sections():
+            sections[section] = dict(self._parser.items(section))
+        return sections
 
     def as_dict(self):
-        return self._parser.as_dict()
 
-    # def add_global(self,
-    #                pg_num=None,
-    #                heartbeat_interval=None,
-    #                osd_heartbeat_interval=None,
-    #                osd_heartbeat_grace=None,
-    #                is_cephx=True,
-    #                max_file=131072,
-    #                down_out_interval=90,
-    #                pool_default_size=3):
+        # NOTE: This method is redundant, returning the same content as as_sections above.
 
-    def add_global(self,dict_kvs={}):
+        return self.as_sections()
+
+    def add_global(self, dict_kvs={}):
+
+        # NOTE: Possibly found in dict_kvs:
+        #     is_cephx=True
+        #     max_file=131072
+        #     down_out_interval=90
+        #     pool_default_size=3
+
         dict_kvs['max_file'] = dict_kvs.get('max_file',131072)
         dict_kvs['is_cephx'] = dict_kvs.get('is_cephx',True)
         dict_kvs['down_out_interval'] = dict_kvs.get('down_out_interval',True)
         dict_kvs['pool_default_size'] = dict_kvs.get('pool_default_size',3)
 
-        self._parser.add_section('global')
+        section = 'global'
+        if not self._parser.has_section(section):
+            self._parser.add_section(section)
         if not dict_kvs['is_cephx']:
-            self._parser.set('global', 'auth supported', 'none')
+            self._parser.set(section, 'auth supported', 'none')
         else:
-            self._parser.set('global', 'auth supported', 'cephx')
-        self._parser.set('global', 'max open files', str(dict_kvs['max_file']))
-        self._parser.set('global',
-                         'mon osd down out interval',
-                         str(dict_kvs['down_out_interval']))
+            self._parser.set(section, 'auth supported', 'cephx')
+        self._parser.set(section, 'max open files', str(dict_kvs['max_file']))
+        self._parser.set(section, 'mon osd down out interval', str(dict_kvs['down_out_interval']))
 
         for key,value in dict_kvs.items():
-            if  key not in ['max_file','is_cephx','down_out_interval','pool_default_size']:
-                self._parser.set('global',
-                         key.replace('_',' '),
-                         str(dict_kvs[key]))
+            if key not in ['max_file','is_cephx','down_out_interval','pool_default_size']:
+                self._parser.set(section, key, str(value))
+
         # Must add fsid for create cluster in newer version of ceph.
         # In order to support lower version of vsm.
         # We set keyring path here.
         # keyring = /etc/ceph/keyring.admin
-        self._parser.set('global', 'keyring', '/etc/ceph/keyring.admin')
+        self._parser.set(section, 'keyring', '/etc/ceph/keyring.admin')
         # Have to setup fsid.
-        self._parser.set('global', 'fsid', str(uuid.uuid1()))
+        self._parser.set(section, 'fsid', str(uuid.uuid1()))
 
     def add_mds_header(self, dict_kvs={}):
         if self._parser.has_section('mds'):
             return
         dict_kvs['keyring'] = dict_kvs.get('keyring','false')
 
-        self._parser.add_section('mds')
-        # NOTE : settings for mds.
-        self._parser.set('mds', 'mds data', '/var/lib/ceph/mds/ceph-$id')
-        self._parser.set('mds', 'mds standby replay', dict_kvs['keyring'])
-        self._parser.set('mds', 'keyring', '/etc/ceph/keyring.$name')
+        section = 'mds'
+        if not self._parser.has_section(section):
+            self._parser.add_section(section)
+        self._parser.set(section, 'mds data', '/var/lib/ceph/mds/ceph-$id')
+        self._parser.set(section, 'mds standby replay', dict_kvs['keyring'])
+        self._parser.set(section, 'keyring', '/etc/ceph/keyring.$name')
         for key,value in dict_kvs.items():
-            if  key not in ['keyring']:
-                self._parser.set('mds',
-                         key.replace('_',' '),
-                         str(dict_kvs[key]))
+            if key not in ['keyring']:
+                self._parser.set(section, key, str(value))
 
     def add_mon_header(self, dict_kvs={}):
         if self._parser.has_section('mon'):
@@ -359,31 +221,27 @@ class CephConfigParser(manager.Manager):
         dict_kvs['cnfth'] = dict_kvs.get('cnfth',None)
         dict_kvs['cfth'] = dict_kvs.get('cfth',None)
 
-        self._parser.add_section('mon')
-        # NOTE
-        # the default mon data dir set in ceph-deploy.
-        # is in:
-        # /var/lib/ceph/mon/ceph-$id/
-        # In order to support created by mkcephfs and live update.
-        # We have to set it to: mon_data="/var/lib/ceph/mon/mon$id"
+        section = 'mon'
+        if not self._parser.has_section(section):
+            self._parser.add_section(section)
+        # NOTE: The default mon data dir set in ceph-deploy is in: /var/lib/ceph/mon/ceph-$id/
+        # In order to support created by mkcephfs and live update,
+        # we have to set it to: mon_data="/var/lib/ceph/mon/mon$id"
         mon_data = "/var/lib/ceph/mon/mon$id"
-        self._parser.set('mon', 'mon data', mon_data)
-        self._parser.set('mon',
-                         'mon clock drift allowed',
-                         '.' + str(dict_kvs['clock_drift']))
+        self._parser.set(section, 'mon data', mon_data)
+        self._parser.set(section, 'mon clock drift allowed', '.' + str(dict_kvs['clock_drift']))
         if dict_kvs['cfth']:
-            self._parser.set('mon', 'mon osd full ratio', '.' + str(dict_kvs['cfth']))
+            self._parser.set(section, 'mon osd full ratio', '.' + str(dict_kvs['cfth']))
         if dict_kvs['cnfth']:
-            self._parser.set('mon', 'mon osd nearfull ratio', '.' + str(dict_kvs['cnfth']))
+            self._parser.set(section, 'mon osd nearfull ratio', '.' + str(dict_kvs['cnfth']))
         for key,value in dict_kvs.items():
-            if  key not in ['clock_drift','cnfth','cfth']:
-                self._parser.set('mon',
-                         key.replace('_',' '),
-                         str(dict_kvs[key]))
+            if key not in ['clock_drift','cnfth','cfth']:
+                self._parser.set(section, key, str(value))
 
     def _update_ceph_conf_into_db(self, content):
         if not self.cluster_id:
             if not self._get_cluster_id():
+                LOG.debug('Can not get cluster_id; unable to save ceph.conf to db')
                 return
 
         db.cluster_update_ceph_conf(self.context, self.cluster_id, content)
@@ -391,22 +249,26 @@ class CephConfigParser(manager.Manager):
         for ser in server_list:
             self._agent_rpcapi.update_ceph_conf(self.context, ser['host'])
 
-    def save_conf(self, file_path=FLAGS.ceph_conf, rgw=False):
-        utils.execute('chown',
-                      '-R',
-                      'vsm:vsm',
-                      '/etc/ceph/',
-                      run_as_root=True)
+    def content(self):
+        sfp = StringIO()
+        self._parser.write(sfp)
+        return sfp.getvalue()
 
-        self._parser.write(file_path, rgw)
-        self._update_ceph_conf_into_db(self._parser.as_str(rgw))
+    def save_conf(self, file_path=FLAGS.ceph_conf, rgw=False):
+        content = self.content()
+        utils.write_file_as_root(file_path, content)
+        self._update_ceph_conf_into_db(content)
 
     def add_mon(self, hostname, ip, mon_id):
+
+        # NOTE: This routine is obsolete since ceph.conf no longer requires [mon.X] sections.
+
         sec = 'mon.%s' % mon_id
         if self._parser.has_section(sec):
             return
 
-        self._parser.add_section(sec)
+        if not self._parser.has_section(sec):
+            self._parser.add_section(sec)
         self._parser.set(sec, 'host', hostname)
         ips = ip.split(',')
         ip_strs = ['%s:%s' % (i, str(6789)) for i in ips]
@@ -414,14 +276,17 @@ class CephConfigParser(manager.Manager):
         self._parser.set(sec, 'mon addr', ip_str)
 
     def add_mds(self, hostname, ip, mds_id):
+
+        # NOTE: This routine is obsolete since ceph.conf no longer requires [mds.X] sections.
+
         sec = 'mds.%s' % mds_id
         if self._parser.has_section(sec):
             return
 
-        self._parser.add_section(sec)
+        if not self._parser.has_section(sec):
+            self._parser.add_section(sec)
         self._parser.set(sec, 'host', hostname)
         self._parser.set(sec, 'public addr', '%s' % ip)
-
 
     def add_osd_header(self, dict_kvs={}):
         if self._parser.has_section('osd'):
@@ -430,47 +295,48 @@ class CephConfigParser(manager.Manager):
         dict_kvs['osd_type'] = dict_kvs.get('osd_type','xfs')
         dict_kvs['osd_heartbeat_interval'] = dict_kvs.get('osd_heartbeat_interval',10)
         dict_kvs['osd_heartbeat_grace'] = dict_kvs.get('osd_heartbeat_grace',10)
-        self._parser.add_section('osd')
+
+        section = 'osd'
+        if not self._parser.has_section(section):
+            self._parser.add_section(section)
         # NOTE Do not add osd data here.
-        self._parser.set('osd', 'osd journal size', str(dict_kvs['journal_size']))
-        self._parser.set('osd', 'filestore xattr use omap', 'true')
-        self._parser.set('osd', 'osd crush update on start', 'false' )
+        self._parser.set(section, 'osd journal size', str(dict_kvs['journal_size']))
+        self._parser.set(section, 'filestore xattr use omap', 'true')
+        self._parser.set(section, 'osd crush update on start', 'false' )
         osd_data = "/var/lib/ceph/osd/osd$id"
-        self._parser.set('osd', 'osd data', osd_data)
+        self._parser.set(section, 'osd data', osd_data)
         # NOTE add keyring to support lower version of OSD.
         # keyring = /etc/ceph/keyring.$name
-        self._parser.set('osd', 'keyring', '/etc/ceph/keyring.$name')
-        self._parser.set('osd', 'osd heartbeat interval', str(dict_kvs['osd_heartbeat_interval']))
-        self._parser.set('osd', 'osd heartbeat grace', str(dict_kvs['osd_heartbeat_grace']))
-        self._parser.set('osd', 'osd mkfs type', dict_kvs['osd_type'])
+        self._parser.set(section, 'keyring', '/etc/ceph/keyring.$name')
+        self._parser.set(section, 'osd heartbeat interval', str(dict_kvs['osd_heartbeat_interval']))
+        self._parser.set(section, 'osd heartbeat grace', str(dict_kvs['osd_heartbeat_grace']))
+        self._parser.set(section, 'osd mkfs type', dict_kvs['osd_type'])
         cluster = db.cluster_get_all(self.context)[0]
         mount_option = cluster['mount_option']
         if not mount_option:
             mount_option = utils.get_fs_options(dict_kvs['osd_type'])[1]
-        self._parser.set('osd', 'osd mount options %s' % dict_kvs['osd_type'], mount_option)
+        self._parser.set(section, 'osd mount options %s' % dict_kvs['osd_type'], mount_option)
 
         # Below is very important for set file system.
         # Do not change any of them.
         format_type = '-f'
         if dict_kvs['osd_type'].lower() == 'ext4':
             format_type = '-F'
-        self._parser.set('osd', 'osd mkfs options %s' % dict_kvs['osd_type'], format_type)
+        self._parser.set(section, 'osd mkfs options %s' % dict_kvs['osd_type'], format_type)
         for key,value in dict_kvs.items():
             if key not in ['journal_size','osd_type','osd_heartbeat_interval','osd_heartbeat_grace']:
-                self._parser.set('osd', key.replace("_",' '), str(value))
+                self._parser.set(section, key, str(value))
 
-    def add_osd(self,
-                hostname,
-                pub_addr,
-                cluster_addr,
-                osd_dev,
-                journal_dev,
-                osd_id):
+    def add_osd(self, hostname, pub_addr, cluster_addr, osd_dev, journal_dev, osd_id):
+
+        # NOTE: This routine is obsolete since ceph.conf no longer requires [osd.X] sections.
+
         sec = 'osd.%s' % osd_id
         if self._parser.has_section(sec):
             return
 
-        self._parser.add_section(sec)
+        if not self._parser.has_section(sec):
+            self._parser.add_section(sec)
         if hostname is None \
            or pub_addr is None\
            or cluster_addr is None \
@@ -484,9 +350,7 @@ class CephConfigParser(manager.Manager):
         # a list or tuple of public ip
         if hasattr(pub_addr, '__iter__'):
             ip_str = ','.join([ip for ip in pub_addr])
-            self._parser.set(sec,
-                             'public addr',
-                             ip_str)
+            self._parser.set(sec, 'public addr', ip_str)
         else:
             self._parser.set(sec, 'public addr', pub_addr)
 
@@ -495,6 +359,9 @@ class CephConfigParser(manager.Manager):
         self._parser.set(sec, 'devs', osd_dev)
 
     def _remove_section(self, typ, num):
+
+        # NOTE: This routine is obsolete since ceph.conf no longer requires [TYP.X] sections.
+
         sec = '%s.%s' % (typ, num)
         if not self._parser.has_section(sec):
             return True
@@ -506,12 +373,21 @@ class CephConfigParser(manager.Manager):
         return self._parser.remove_section('mds')
 
     def remove_osd(self, osd_id):
+
+        # NOTE: This routine is obsolete since ceph.conf no longer requires [osd.X] sections.
+
         return self._remove_section('osd', osd_id)
 
     def remove_mon(self, mon_id):
+
+        # NOTE: This routine is obsolete since ceph.conf no longer requires [mon.X] sections.
+
         return self._remove_section('mon', mon_id)
 
     def remove_mds(self, mds_id):
+
+        # NOTE: This routine is obsolete since ceph.conf no longer requires [mds.X] sections.
+
         return self._remove_section('mds', mds_id)
 
     def add_rgw(self, rgw_sec, host, keyring, log_file, rgw_frontends):

--- a/source/vsm/vsm/agent/cephconfigparser.py
+++ b/source/vsm/vsm/agent/cephconfigparser.py
@@ -115,17 +115,17 @@ class CephConfigParser(manager.Manager):
         super(CephConfigParser, self).__init__(*args, **kwargs)
         self._parser = ConfigParser.ConfigParser()
         self._parser.optionxform = lambda optname: optname.lower().replace(' ', '_')
+        self._load_ceph_conf_from_db()
 
         # NOTE: fp can be a file name in str or unicode format OR a dictionary of dictionaries
 
-        if fp is None:
-            self._load_ceph_conf_from_db()
-        elif isinstance(fp, str) or isinstance(fp, unicode):
-            self._parser.read(fp)
-        elif isinstance(fp, dict):
-            self._load_ceph_conf_from_dict(fp)
-        else:
-            raise TypeError("'fp' must be a string or dictionary")
+        if fp is not None:
+            if isinstance(fp, str) or isinstance(fp, unicode):
+                self._parser.read(fp)
+            elif isinstance(fp, dict):
+                self._load_ceph_conf_from_dict(fp)
+            else:
+                raise TypeError("'fp' must be a string or dictionary")
 
     # NOTE: The following methods are obsolete since ceph.conf files no longer contain [mon.X], [mds.X], and [ods.X] sections
 

--- a/source/vsm/vsm/agent/manager.py
+++ b/source/vsm/vsm/agent/manager.py
@@ -2042,7 +2042,7 @@ class AgentManager(manager.Manager):
             ceph_conf = body.get('ceph_conf')
             ceph_conf_file_new = '%s-import'%FLAGS.ceph_conf
             utils.write_file_as_root(ceph_conf_file_new, ceph_conf, 'w')
-            config_content = cephconfigparser.CephConfigParser(fp=str(ceph_conf_file_new))._parser.as_str()
+            config_content = cephconfigparser.CephConfigParser(fp=str(ceph_conf_file_new)).content()
             osd_info = self.ceph_driver.get_ceph_osd_info()
             mon_info = self.ceph_driver._get_ceph_mon_map()
             self._modify_init_nodes_from_config_to_db(context,osd_info,mon_info,crushmap)

--- a/source/vsm/vsm/agent/manager.py
+++ b/source/vsm/vsm/agent/manager.py
@@ -83,7 +83,7 @@ class AgentManager(manager.Manager):
         super(AgentManager, self).__init__(*args, **kwargs)
         self._context = context.get_admin_context()
         self._driver = driver.DbDriver()
-        self.ceph_driver = driver.CephDriver()
+        self.ceph_driver = driver.CephDriver(self._context)
         self.crushmap_driver = driver.CreateCrushMapDriver()
         self.crushmap_manager_driver = driver.ManagerCrushMapDriver()
         self.diamond_driver= driver.DiamondDriver()
@@ -466,7 +466,7 @@ class AgentManager(manager.Manager):
 
     def update_ceph_conf(self, context):
         LOG.info('agent/manager.py update ceph.conf from db.')
-        cephconfigparser.CephConfigParser(FLAGS.ceph_conf)
+        self.ceph_driver.sync_db_to_ceph_config_file(context)
         LOG.info('agent/manager.py update ceph.conf from db. OVER')
 
     def get_ceph_admin_keyring(self, context):
@@ -686,9 +686,6 @@ class AgentManager(manager.Manager):
 
     def get_ceph_config(self, context):
         return self.ceph_driver.get_ceph_config(context)
-
-    def save_ceph_config(self, context, config):
-        return self.ceph_driver.save_ceph_config(context, config)
 
     def start_monitor(self, context):
         # Start all the monitors

--- a/source/vsm/vsm/agent/rpcapi.py
+++ b/source/vsm/vsm/agent/rpcapi.py
@@ -148,12 +148,6 @@ class AgentAPI(vsm.openstack.common.rpc.proxy.RpcProxy):
                         self.make_msg('get_ceph_config',),
                         topic, version='1.0', timeout=6000)
 
-    def save_ceph_config(self, context, config, host):
-        topic = rpc.queue_get_for(context, self.topic, host)
-        return self.call(context,
-                        self.make_msg('save_ceph_config', config=config),
-                    topic, version='1.0', timeout=6000)
-
     def get_ceph_admin_keyring(self, context, host,):
         topic = rpc.queue_get_for(context, self.topic, host)
         return self.call(context,
@@ -407,7 +401,6 @@ class AgentAPI(vsm.openstack.common.rpc.proxy.RpcProxy):
     def update_ceph_conf(self, context, host):
         topic = rpc.queue_get_for(context, self.topic, host)
         self.cast(context, self.make_msg('update_ceph_conf'), topic)
-
 
     def start_monitor(self, context, host):
         topic = rpc.queue_get_for(context, self.topic, host)

--- a/source/vsm/vsm/api/v1/clusters.py
+++ b/source/vsm/vsm/api/v1/clusters.py
@@ -139,9 +139,8 @@ class ClusterController(wsgi.Controller):
         cluster_name = body["cluster"]["cluster_name"]
         cluster = db.cluster_get_by_name(context,cluster_name)
         if cluster:
-            ceph_conf_dict_old = cephconfigparser.CephConfigParser(FLAGS.ceph_conf)._parser.as_dict()
-            ceph_conf_parser = cephconfigparser.CephConfigParser(ceph_conf_path)._parser
-            ceph_conf_dict = ceph_conf_parser.as_dict()
+            ceph_conf_dict_old = cephconfigparser.CephConfigParser(FLAGS.ceph_conf).as_dict()
+            ceph_conf_dict = cephconfigparser.CephConfigParser(ceph_conf_path).as_dict()
             check_ret = check_ceph_conf(ceph_conf_dict_old,ceph_conf_dict)
             if check_ret:
                 return {"message":"%s"%check_ret}

--- a/source/vsm/vsm/scheduler/manager.py
+++ b/source/vsm/vsm/scheduler/manager.py
@@ -1152,8 +1152,7 @@ class SchedulerManager(manager.Manager):
         """
         """
         LOG.info('import ceph conf from %s to db '%ceph_conf_path)#ceph_conf_path!=FLAG.ceph_conf
-        ceph_conf_parser = cephconfigparser.CephConfigParser(str(ceph_conf_path))._parser
-        ceph_conf_str = ceph_conf_parser.as_str()
+        ceph_conf_str = cephconfigparser.CephConfigParser(ceph_conf_path).content()
         db.cluster_update_ceph_conf(context, cluster_id, ceph_conf_str)
         server_list = db.init_node_get_all(context)
         LOG.info('import ceph conf from db to ceph nodes ')
@@ -1226,8 +1225,7 @@ class SchedulerManager(manager.Manager):
         ceph_conf = body.get('ceph_conf')
         ceph_conf_file_new = '%s-check'%FLAGS.ceph_conf
         utils.write_file_as_root(ceph_conf_file_new, ceph_conf, 'w')
-        config = cephconfigparser.CephConfigParser(fp=ceph_conf_file_new)
-        config_dict = config.as_dict()
+        config_dict = cephconfigparser.CephConfigParser(ceph_conf_file_new).as_dict()
         if config_dict is None:
             message['code'].append('-26')
             message['error'].append('the format of ceph_conf error.')


### PR DESCRIPTION
Yaguang - I've tested this code - it works just as the hand-written parser does. My next changeset will clean up the obsolete routines, but that will require modifying calling code, so I wanted to keep that change set separate from this one.

The key to making python's ConfigParser work correctly is using the proper optionxform function - see line 64 - this code uses a lambda that converts to lowercase and replaces internal spaces with underscores for comparison purposes. Thus, option names with spaces and underscores compare properly.