### PR TITLE
Fix eval and remote ssh commands to use set -e correctly.

### DIFF
--- a/ubuntu14/install.sh
+++ b/ubuntu14/install.sh
@@ -154,7 +154,7 @@ declare -a on_exit_items
 function on_exit()
 {
     for i in "${on_exit_items[@]}"; do
-        eval $i
+        eval $i || :
     done
 }
 
@@ -285,7 +285,11 @@ function prepare() {
 function execute() {                    # execute "<command>" [[<user>@]<host>]
     local command="$1"
     local remote="$2"
-    [[ $remote ]] && eval $SSH $remote "\"$command\"" || eval "$command"
+    if [ ! -z "$remote" ]; then
+        $SSH $remote "set -e; $command; true"
+    else
+        eval "$command; true"
+    fi
 }
 
 function copy() {                       # copy [-<op1> -<op2> ...] <src> <dst> [[<user>@]<host>]


### PR DESCRIPTION
Hi Yaguang - this is a minor fix to my last set of install.sh changes. This fix allows set -e to work correctly in the context of ssh remote commands and local eval commands.