### PR TITLE
scheduler: add flag to judge success or error in add_storage_group_to…

### DIFF
--- a/source/vsm-dashboard/vsm_dashboard/dashboards/vsm/crushmap/views.py
+++ b/source/vsm-dashboard/vsm_dashboard/dashboards/vsm/crushmap/views.py
@@ -103,7 +103,7 @@ def create_storage_group(request):
     try:
         http_response_code,ret = vsmapi.storage_group_create_with_takes(request, body=body)
         print '---ret====',ret
-        if len(ret.get('error_code')) > 0:
+        if ret.get('status') == 'error':
             status = "Failed"
             msg = ret.get('error_msg')
         else:

--- a/source/vsm/vsm/scheduler/manager.py
+++ b/source/vsm/vsm/scheduler/manager.py
@@ -2089,6 +2089,7 @@ class SchedulerManager(manager.Manager):
         cluster_id = body.get('cluster_id',None)
         active_monitor = self._get_active_monitor(context, cluster_id=cluster_id)
         LOG.info('sync call to host = %s' % active_monitor['host'])
+        flag = 0
         for storage_group in storage_groups:
 
             rule_info = storage_group['rule_info']
@@ -2112,9 +2113,15 @@ class SchedulerManager(manager.Manager):
                 }
                 #LOG.info('take==444444444=====%s'%storage_group_to_db)
                 db.storage_group_update_or_create(context, storage_group_to_db)
+                flag +=1
                 take_order += 1
-        message = {'info':'Add storage group %s success!'%(','.join([ storage_group['name'] for storage_group in storage_groups])),
-                   'error_code':'','error_msg':''}
+        message = {}
+        if flag >0:
+            message['status'] = 'success'
+            message['info'] = 'Add storage group %s success!'%(','.join([ storage_group['name'] for storage_group in storage_groups]))
+        else:
+            message['status'] = 'error'
+            message['error_msg'] = 'Add Storage Group Failed!'
         return message
 
     def update_storage_group_to_crushmap_and_db(self, context, body):


### PR DESCRIPTION
…_crushmap_and_db

we know ret.get('error_code') is alway equal to zero, although it does not

add storage group, it also return 'success'.So I fix message, when it does not

add stoage group, it return 'error'.
