### PR TITLE
Add page for changing a language of interface

### DIFF
--- a/source/vsm-dashboard/vsm_dashboard/dashboards/vsm/dashboard.py
+++ b/source/vsm-dashboard/vsm_dashboard/dashboards/vsm/dashboard.py
@@ -47,7 +47,7 @@ class OpenstackMgmt(horizon.PanelGroup):
 class UserMgmt(horizon.PanelGroup):
     slug = "usermgmt"
     name = _("VSM Management")
-    panels = ("usermgmt", 'settings')
+    panels = ('language', "usermgmt", 'settings')
 
 class VizDash(horizon.Dashboard):
     name = _("VSM")

--- a/source/vsm-dashboard/vsm_dashboard/dashboards/vsm/language/__init__.py
+++ b/source/vsm-dashboard/vsm_dashboard/dashboards/vsm/language/__init__.py
@@ -1,0 +1,17 @@
+
+# Copyright 2014 Intel Corporation, All Rights Reserved.
+
+# Licensed under the Apache License, Version 2.0 (the"License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#  http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+

--- a/source/vsm-dashboard/vsm_dashboard/dashboards/vsm/language/panel.py
+++ b/source/vsm-dashboard/vsm_dashboard/dashboards/vsm/language/panel.py
@@ -1,0 +1,26 @@
+
+# Copyright 2014 Intel Corporation, All Rights Reserved.
+
+# Licensed under the Apache License, Version 2.0 (the"License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#  http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from django.utils.translation import ugettext_lazy as _
+
+import horizon
+from vsm_dashboard.dashboards.vsm import dashboard
+
+class Language(horizon.Panel):
+    name = _("Language")
+    slug = 'language'
+
+dashboard.VizDash.register(Language)

--- a/source/vsm-dashboard/vsm_dashboard/dashboards/vsm/language/templates/language/index.html
+++ b/source/vsm-dashboard/vsm_dashboard/dashboards/vsm/language/templates/language/index.html
@@ -1,0 +1,55 @@
+
+<!-- Copyright 2014 Intel Corporation, All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the"License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied. See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ --> 
+
+{% extends 'base.html' %}
+{% load i18n %}
+{% block title %}{% trans "Settings" %}{% endblock %}
+
+{% block page_header %}
+  {% include "horizon/common/_page_header.html" with title=_("Settings") %}
+{% endblock page_header %}
+
+{% block main %}
+
+<div class="table_wrapper">
+
+    <form action="/dashboard/i18n/setlang/" method="post">
+    {% csrf_token %}
+    <input name="next" type="hidden" value="{{ redirect_to }}" />
+    <select name="language">
+    {% get_current_language as LANGUAGE_CODE %}
+    {% get_available_languages as LANGUAGES %}
+    {% get_language_info_list for LANGUAGES as languages %}
+    {% for language in languages %}
+    <option value="{{ language.code }}"{% if language.code == LANGUAGE_CODE %} selected="selected"{% endif %}>
+        {{ language.name_local }} ({{ language.code }})
+    </option>
+    {% endfor %}
+    </select>
+    <input type="submit" value="Go" />
+    </form>
+</div>
+
+{% endblock %}
+
+{% block js %}
+    {{ block.super }}
+    <script type="text/javascript">
+
+    </script>
+{% endblock %}
+

--- a/source/vsm-dashboard/vsm_dashboard/dashboards/vsm/language/urls.py
+++ b/source/vsm-dashboard/vsm_dashboard/dashboards/vsm/language/urls.py
@@ -1,0 +1,22 @@
+
+# Copyright 2014 Intel Corporation, All Rights Reserved.
+
+# Licensed under the Apache License, Version 2.0 (the"License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#  http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from django.conf.urls import patterns, url
+from .views import IndexView
+
+urlpatterns = patterns('',
+    url(r'^$', IndexView.as_view(), name='index'),
+)

--- a/source/vsm-dashboard/vsm_dashboard/dashboards/vsm/language/views.py
+++ b/source/vsm-dashboard/vsm_dashboard/dashboards/vsm/language/views.py
@@ -1,0 +1,29 @@
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
+
+# Copyright 2014 Intel Corporation, All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import logging
+import json
+
+from django.http import HttpResponse
+from django.views.generic import TemplateView
+
+LOG = logging.getLogger(__name__)
+
+class IndexView(TemplateView):
+    template_name = 'vsm/language/index.html'
+    def get_context_data(self, **kwargs):
+        context = super(IndexView, self).get_context_data(**kwargs)
+        return context

--- a/source/vsm-dashboard/vsm_dashboard/urls.py
+++ b/source/vsm-dashboard/vsm_dashboard/urls.py
@@ -34,6 +34,7 @@ urlpatterns = patterns('',
     url(r'^license_cancel/', 'vsm_dashboard.views.license_cancel',
         name='license_cancel'),
     url(r'^home/', RedirectView.as_view(url='/dashboard/vsm/')),
+    url(r'^i18n/', include('django.conf.urls.i18n'), name='set_language'),
     url(r'', include(horizon.urls))
 )
 


### PR DESCRIPTION
This will add `Language` "submenu" under `VSM Management` "menu" in order to give user ability to change VSM's interface language manually.