### PR TITLE
agent/manager: delete data from db in metrics

### DIFF
--- a/source/vsm/vsm/agent/manager.py
+++ b/source/vsm/vsm/agent/manager.py
@@ -1212,7 +1212,7 @@ class AgentManager(manager.Manager):
                 # db.osd_delete(context, osd_id)
                 # db.device_delete(context, device_id)
 
-    @periodic_task(service_topic=FLAGS.agent_topic,
+    @periodic_task(run_immediately=True,service_topic=FLAGS.agent_topic,
                    spacing=10)
     def clean_performance_history_data(self, context):
         key = 'keep_performance_data_days'


### PR DESCRIPTION
Before it has no run_immediately=True, db can not clean data at regular intervals.

It will cause the database downtime.

Threreforce, I add run_immediately=True.